### PR TITLE
chore(release): Set up @benmvp/cli for public access

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   "repository": "https://github.com/benmvp/benmvp-cli.git",
   "author": "Ben Ilegbodu <ben@benmvp.com>",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "prebootstrap": "rm -rf lib",
     "bootstrap": "babel src --out-dir lib/cjs --extensions '.ts,.js' --copy-files --presets ./src/commands/build/babel-config-cjs.js",


### PR DESCRIPTION

Since this package is a scoped package, the first time it's released, it needs to be published with `npm publish --access public`. But since we're using `semantic-release` we don't have that ability. So an alternative is to add the `publishConfig` property to the `package.json` to set it.