### PR TITLE
feat(command): Add --ci flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 'node'
+  # - 'node'
   - '10'
   - '8'
 cache: yarn

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 
 [![Maintenance Status](https://img.shields.io/badge/status-maintained-brightgreen.svg)](https://github.com/benmvp/benmvp-cli/pulse)
 [![Build Status](https://travis-ci.org/benmvp/benmvp-cli.svg?branch=master)](https://travis-ci.org/benmvp/benmvp-cli)
-[![Tested with jest](https://img.shields.io/badge/tested_with-jest-99424f.svg)](https://github.com/facebook/jest)[![Dependencies status](https://img.shields.io/david/benmvp/benmvp-cli.svg)](https://david-dm.org/benmvp/benmvp-cli)
+[![Tested with jest](https://img.shields.io/badge/tested_with-jest-99424f.svg)](https://github.com/facebook/jest)
+[![Dependencies status](https://img.shields.io/david/benmvp/benmvp-cli.svg)](https://david-dm.org/benmvp/benmvp-cli)
 [![Dev Dependencies status](https://img.shields.io/david/dev/benmvp/benmvp-cli.svg)](https://david-dm.org/benmvp/benmvp-cli?type=dev)
 [![Greenkeeper badge](https://badges.greenkeeper.io/benmvp/benmvp-cli.svg)](https://greenkeeper.io/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@benmvp/cli",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "A highly-opinionated, zero-config CLI for consistent infra for Ben Ilegbodu's Typescript-based libraries",
   "main": "lib/cjs/index.js",
   "module": "lib/esm/index.js",
@@ -53,6 +53,7 @@
     "jest": "^23.6.0",
     "jest-runner-eslint": "^0.7.1",
     "jest-runner-tsc": "^1.3.2",
+    "jest-watch-typeahead": "^0.3.0",
     "lodash": "^4.17.11",
     "typescript": "^3.2.1",
     "typescript-eslint-parser": "^21.0.2",

--- a/src/commands/start/__tests__/index.spec.ts
+++ b/src/commands/start/__tests__/index.spec.ts
@@ -45,31 +45,17 @@ describe('success cases', () => {
     runJest.mockReset()
   })
 
-  it('calls jest with args and returns success when no options are passed', async () => {
-    const result = await start()
-
-    expect(runJest).toHaveBeenCalledWith([
-      '--watch',
-      '--projects',
-      expect.stringContaining('project-type.js'),
-      expect.stringContaining('project-lint.js'),
-      expect.stringContaining('project-unit.js'),
-    ])
-
-    expect(result).toEqual({code: 0})
-  })
-
   describe('modes', () => {
     it('calls jest with args and returns success when no modes are passed', async () => {
       const result = await start({})
 
-      expect(runJest).toHaveBeenCalledWith([
-        '--watch',
+      expect(runJest).toHaveBeenCalledWith(expect.arrayContaining(['--watch']))
+      expect(runJest).toHaveBeenCalledWith(expect.arrayContaining([
         '--projects',
         expect.stringContaining('project-type.js'),
         expect.stringContaining('project-lint.js'),
         expect.stringContaining('project-unit.js'),
-      ])
+      ]))
 
       expect(result).toEqual({code: 0})
     })
@@ -77,11 +63,11 @@ describe('success cases', () => {
     it('calls jest with args and returns success when valid modes are passed', async () => {
       const result = await start({modes: ['unit']})
 
-      expect(runJest).toHaveBeenCalledWith([
-        '--watch',
+      expect(runJest).toHaveBeenCalledWith(expect.arrayContaining(['--watch']))
+      expect(runJest).toHaveBeenCalledWith(expect.arrayContaining([
         '--projects',
         expect.stringContaining('project-unit.js'),
-      ])
+      ]))
 
       expect(result).toEqual({code: 0})
     })

--- a/src/commands/test/__tests__/index.spec.ts
+++ b/src/commands/test/__tests__/index.spec.ts
@@ -48,12 +48,12 @@ describe('success cases', () => {
   it('calls jest with args and returns success when no options are passed', async () => {
     const result = await testCommand()
 
-    expect(runJest).toHaveBeenCalledWith([
+    expect(runJest).toHaveBeenCalledWith(expect.arrayContaining([
       '--projects',
       expect.stringContaining('project-type.js'),
       expect.stringContaining('project-lint.js'),
       expect.stringContaining('project-unit.js'),
-    ])
+    ]))
 
     expect(result).toEqual({code: 0})
   })
@@ -62,12 +62,12 @@ describe('success cases', () => {
     it('calls jest with args and returns success when no modes are passed', async () => {
       const result = await testCommand({})
 
-      expect(runJest).toHaveBeenCalledWith([
+      expect(runJest).toHaveBeenCalledWith(expect.arrayContaining([
         '--projects',
         expect.stringContaining('project-type.js'),
         expect.stringContaining('project-lint.js'),
         expect.stringContaining('project-unit.js'),
-      ])
+      ]))
 
       expect(result).toEqual({code: 0})
     })
@@ -75,10 +75,10 @@ describe('success cases', () => {
     it('calls jest with args and returns success when valid modes are passed', async () => {
       const result = await testCommand({modes: ['unit']})
 
-      expect(runJest).toHaveBeenCalledWith([
+      expect(runJest).toHaveBeenCalledWith(expect.arrayContaining([
         '--projects',
         expect.stringContaining('project-unit.js'),
-      ])
+      ]))
 
       expect(result).toEqual({code: 0})
     })
@@ -88,10 +88,9 @@ describe('success cases', () => {
     it('calls jest with args and returns success when no watch flag is passed', async () => {
       const result = await testCommand({modes: ['type']})
 
-      expect(runJest).toHaveBeenCalledWith([
-        '--projects',
-        expect.stringContaining('project-type.js'),
-      ])
+      expect(runJest).toHaveBeenCalledWith(expect.not.arrayContaining([
+        '--watch',
+      ]))
 
       expect(result).toEqual({code: 0})
     })
@@ -99,13 +98,29 @@ describe('success cases', () => {
     it('calls jest with args and returns success when watch flag is passed', async () => {
       const result = await testCommand({watch: true, modes: ['lint']})
 
-      expect(runJest).toHaveBeenCalledWith([
+      expect(runJest).toHaveBeenCalledWith(expect.arrayContaining([
         '--watch',
-        '--projects',
-        expect.stringContaining('project-lint.js'),
-      ])
+      ]))
 
       expect(result).toEqual({code: 0})
+    })
+  })
+
+  describe('ci', () => {
+    it('calls jest with --ci flag and returns success when CI env is set', async () => {
+      const origEnvCI = process.env.CI
+
+      process.env.CI = 'true'
+
+      const result = await testCommand()
+
+      expect(runJest).toHaveBeenCalledWith(expect.arrayContaining([
+        '--ci',
+      ]))
+
+      expect(result).toEqual({ code: 0 })
+
+      process.env.CI = origEnvCI
     })
   })
 })

--- a/src/commands/test/__tests__/index.spec.ts
+++ b/src/commands/test/__tests__/index.spec.ts
@@ -5,6 +5,10 @@ import {TestMode} from '../../types'
 jest.mock('../run-jest')
 
 describe('error cases', () => {
+  afterEach(() => {
+    runJest.mockReset()
+  })
+
   it('returns an error w/ empty modes', async () => {
     const result = await testCommand({modes: []})
 
@@ -35,27 +39,12 @@ describe('error cases', () => {
       message: expect.any(String),
       error: expect.any(Error),
     })
-
-    runJest.mockReset()
   })
 })
 
 describe('success cases', () => {
   afterEach(() => {
     runJest.mockReset()
-  })
-
-  it('calls jest with args and returns success when no options are passed', async () => {
-    const result = await testCommand()
-
-    expect(runJest).toHaveBeenCalledWith(expect.arrayContaining([
-      '--projects',
-      expect.stringContaining('project-type.js'),
-      expect.stringContaining('project-lint.js'),
-      expect.stringContaining('project-unit.js'),
-    ]))
-
-    expect(result).toEqual({code: 0})
   })
 
   describe('modes', () => {
@@ -86,7 +75,7 @@ describe('success cases', () => {
 
   describe('watch', () => {
     it('calls jest with args and returns success when no watch flag is passed', async () => {
-      const result = await testCommand({modes: ['type']})
+      const result = await testCommand()
 
       expect(runJest).toHaveBeenCalledWith(expect.not.arrayContaining([
         '--watch',
@@ -96,7 +85,7 @@ describe('success cases', () => {
     })
 
     it('calls jest with args and returns success when watch flag is passed', async () => {
-      const result = await testCommand({watch: true, modes: ['lint']})
+      const result = await testCommand({watch: true})
 
       expect(runJest).toHaveBeenCalledWith(expect.arrayContaining([
         '--watch',
@@ -118,7 +107,7 @@ describe('success cases', () => {
         '--ci',
       ]))
 
-      expect(result).toEqual({ code: 0 })
+      expect(result).toEqual({code: 0})
 
       process.env.CI = origEnvCI
     })

--- a/src/commands/test/__tests__/utils.spec.ts
+++ b/src/commands/test/__tests__/utils.spec.ts
@@ -41,8 +41,8 @@ describe('getJestArgs', () => {
       const actual = getJestArgs({modes: ['type'], watch: false})
 
       expect(actual).toEqual(expect.arrayContaining([
-        '--projects', 
-        expect.stringContaining('project-type.js')
+        '--projects',
+        expect.stringContaining('project-type.js'),
       ]))
     })
 
@@ -65,7 +65,7 @@ describe('getJestArgs', () => {
     })
 
     it('does not include --watch flag when watch option is specified as false', () => {
-      const actual = getJestArgs({ watch: false, modes: ['unit'] })
+      const actual = getJestArgs({watch: false, modes: ['unit']})
 
       expect(actual).not.toContain('--watch')
     })
@@ -89,7 +89,7 @@ describe('getJestArgs', () => {
 
       process.env.CI = 'false'
 
-      const actual = getJestArgs({ modes: ['unit'], watch: false })
+      const actual = getJestArgs({modes: ['unit'], watch: false})
 
       expect(actual).not.toContain('--ci')
 

--- a/src/commands/test/__tests__/utils.spec.ts
+++ b/src/commands/test/__tests__/utils.spec.ts
@@ -40,17 +40,20 @@ describe('getJestArgs', () => {
     it('returns single project when single valid mode is specified', () => {
       const actual = getJestArgs({modes: ['type'], watch: false})
 
-      expect(actual).toEqual(['--projects', expect.stringContaining('project-type.js')])
+      expect(actual).toEqual(expect.arrayContaining([
+        '--projects', 
+        expect.stringContaining('project-type.js')
+      ]))
     })
 
     it('returns multiple projects when multiple valid modes are specified', () => {
       const actual = getJestArgs({modes: ['lint', 'unit'], watch: false})
 
-      expect(actual).toEqual([
+      expect(actual).toEqual(expect.arrayContaining([
         '--projects',
         expect.stringContaining('project-lint.js'),
         expect.stringContaining('project-unit.js'),
-      ])
+      ]))
     })
   })
 
@@ -58,7 +61,13 @@ describe('getJestArgs', () => {
     it('includes --watch flag when watch option is specified as true', () => {
       const actual = getJestArgs({watch: true, modes: ['unit']})
 
-      expect(actual).toEqual(['--watch', '--projects', expect.stringContaining('project-unit.js')])
+      expect(actual).toContain('--watch')
+    })
+
+    it('does not include --watch flag when watch option is specified as false', () => {
+      const actual = getJestArgs({ watch: false, modes: ['unit'] })
+
+      expect(actual).not.toContain('--watch')
     })
   })
 
@@ -76,9 +85,15 @@ describe('getJestArgs', () => {
     })
 
     it('does not include --ci flag when process.env.CI is unspecified', () => {
-      const actual = getJestArgs({modes: ['unit'], watch: false})
+      const origEnvCI = process.env.CI
+
+      process.env.CI = 'false'
+
+      const actual = getJestArgs({ modes: ['unit'], watch: false })
 
       expect(actual).not.toContain('--ci')
+
+      process.env.CI = origEnvCI
     })
   })
 })

--- a/src/commands/test/__tests__/utils.spec.ts
+++ b/src/commands/test/__tests__/utils.spec.ts
@@ -61,4 +61,24 @@ describe('getJestArgs', () => {
       expect(actual).toEqual(['--watch', '--projects', expect.stringContaining('project-unit.js')])
     })
   })
+
+  describe('ci', () => {
+    it('includes --ci flag when process.env.CI is true', () => {
+      const origEnvCI = process.env.CI
+
+      process.env.CI = 'true'
+
+      const actual = getJestArgs({modes: ['unit'], watch: false})
+
+      expect(actual).toContain('--ci')
+
+      process.env.CI = origEnvCI
+    })
+
+    it('does not include --ci flag when process.env.CI is unspecified', () => {
+      const actual = getJestArgs({modes: ['unit'], watch: false})
+
+      expect(actual).not.toContain('--ci')
+    })
+  })
 })

--- a/src/commands/test/project-base.js
+++ b/src/commands/test/project-base.js
@@ -14,4 +14,8 @@ module.exports = {
     '^.+\\.(ts|js)$': resolve(__dirname, './babel-jest-transform.js'),
   },
   testMatch: [resolve(REAL_ROOT_DIR, 'src/**/*.ts')],
+  watchPlugins: [
+    'jest-watch-typeahead/filename',
+    'jest-watch-typeahead/testname',
+  ],
 }

--- a/src/commands/test/utils.ts
+++ b/src/commands/test/utils.ts
@@ -36,6 +36,10 @@ export const getJestArgs = ({modes, watch}: Args): Array<string> => {
     jestArgs = [...jestArgs, '--watch']
   }
 
+  if (process.env.CI === 'true') {
+    jestArgs = [...jestArgs, '--ci']
+  }
+
   const validModes = modes.filter((mode) => mode in VALID_TEST_MODES)
 
   if (!validModes.length || validModes.length < modes.length) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -734,6 +734,55 @@
     lodash "^4.17.10"
     to-fast-properties "^2.0.0"
 
+"@jest/console@^24.7.1":
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/@jest/console/-/console-24.7.1.tgz#32a9e42535a97aedfe037e725bd67e954b459545"
+  integrity sha512-iNhtIy2M8bXlAOULWVTUxmnelTLFneTNEkHCgPmgd+zNwy9zVddJ6oS5rZ9iwoscNdT5mMwUd0C51v/fSlzItg==
+  dependencies:
+    "@jest/source-map" "^24.3.0"
+    chalk "^2.0.1"
+    slash "^2.0.0"
+
+"@jest/fake-timers@^24.7.1":
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/@jest/fake-timers/-/fake-timers-24.7.1.tgz#56e5d09bdec09ee81050eaff2794b26c71d19db2"
+  integrity sha512-4vSQJDKfR2jScOe12L9282uiwuwQv9Lk7mgrCSZHA9evB9efB/qx8i0KJxsAKtp8fgJYBJdYY7ZU6u3F4/pyjA==
+  dependencies:
+    "@jest/types" "^24.7.0"
+    jest-message-util "^24.7.1"
+    jest-mock "^24.7.0"
+
+"@jest/source-map@^24.3.0":
+  version "24.3.0"
+  resolved "https://registry.yarnpkg.com/@jest/source-map/-/source-map-24.3.0.tgz#563be3aa4d224caf65ff77edc95cd1ca4da67f28"
+  integrity sha512-zALZt1t2ou8le/crCeeiRYzvdnTzaIlpOWaet45lNSqNJUnXbppUUFR4ZUAlzgDmKee4Q5P/tKXypI1RiHwgag==
+  dependencies:
+    callsites "^3.0.0"
+    graceful-fs "^4.1.15"
+    source-map "^0.6.0"
+
+"@jest/test-result@^24.7.1":
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/@jest/test-result/-/test-result-24.7.1.tgz#19eacdb29a114300aed24db651e5d975f08b6bbe"
+  integrity sha512-3U7wITxstdEc2HMfBX7Yx3JZgiNBubwDqQMh+BXmZXHa3G13YWF3p6cK+5g0hGkN3iufg/vGPl3hLxQXD74Npg==
+  dependencies:
+    "@jest/console" "^24.7.1"
+    "@jest/types" "^24.7.0"
+    "@types/istanbul-lib-coverage" "^2.0.0"
+
+"@jest/types@^24.7.0":
+  version "24.7.0"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-24.7.0.tgz#c4ec8d1828cdf23234d9b4ee31f5482a3f04f48b"
+  integrity sha512-ipJUa2rFWiKoBqMKP63Myb6h9+iT3FHRTF2M8OR6irxWzItisa8i4dcSg14IbvmXUnBlHBlUQPYUHWyX3UPpYA==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/yargs" "^12.0.9"
+
+"@types/istanbul-lib-coverage@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.0.tgz#1eb8c033e98cf4e1a4cedcaf8bcafe8cb7591e85"
+  integrity sha512-eAtOAFZefEnfJiRFQBGw1eYqa5GTLCZ1y86N0XSI/D6EB+E8z6VPV/UL7Gi5UEclFqoQk+6NRqEDsfmDLXn8sg==
+
 "@types/jest-diff@*":
   version "20.0.1"
   resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
@@ -763,6 +812,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.6.tgz#37ec75690830acb0d74ce3c6c43caab787081e85"
   integrity sha512-Xoo/EBzEe8HxTSwaZNLZjaW6M6tA/+GmD3/DZ6uo8qSaolE/9Oarko0oV1fVfrLqOz0tx0nXJB4rdD5c+vixLw==
 
+"@types/stack-utils@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
+  integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
 "@types/typescript@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@types/typescript/-/typescript-2.0.0.tgz#c433539c98bae28682b307eaa7a0fd2115b83c28"
@@ -774,6 +828,11 @@
   version "13.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-13.0.0.tgz#453743c5bbf9f1bed61d959baab5b06be029b2d0"
   integrity sha512-wBlsw+8n21e6eTd4yVv8YD/E3xq0O6nNnJIquutAsFGE7EyMKz7W6RNT6BRu1SmdgmlCZ9tb0X+j+D6HGr8pZw==
+
+"@types/yargs@^12.0.9":
+  version "12.0.12"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-12.0.12.tgz#45dd1d0638e8c8f153e87d296907659296873916"
+  integrity sha512-SOhuU4wNBxhhTHxYaiG5NY4HBhDIDnJF60GU+2LqHAdKKer86//e4yg69aENCtQ04n0ovz+tq2YPME5t5yp4pw==
 
 "@types/yargs@^13.0.0":
   version "13.0.0"
@@ -1496,6 +1555,11 @@ ci-info@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-1.6.0.tgz#2ca20dbb9ceb32d4524a683303313f0304b1e497"
   integrity sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==
+
+ci-info@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
+  integrity sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
 
 circular-json@^0.3.1:
   version "0.3.3"
@@ -2637,7 +2701,7 @@ globals@^9.18.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
   integrity sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
@@ -2950,6 +3014,13 @@ is-ci@^1.0.10:
   integrity sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==
   dependencies:
     ci-info "^1.5.0"
+
+is-ci@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
+  integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
+  dependencies:
+    ci-info "^2.0.0"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -3429,10 +3500,31 @@ jest-message-util@^23.4.0:
     slash "^1.0.0"
     stack-utils "^1.0.1"
 
+jest-message-util@^24.7.1:
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/jest-message-util/-/jest-message-util-24.7.1.tgz#f1dc3a6c195647096a99d0f1dadbc447ae547018"
+  integrity sha512-dk0gqVtyqezCHbcbk60CdIf+8UHgD+lmRHifeH3JRcnAqh4nEyPytSc9/L1+cQyxC+ceaeP696N4ATe7L+omcg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@jest/test-result" "^24.7.1"
+    "@jest/types" "^24.7.0"
+    "@types/stack-utils" "^1.0.1"
+    chalk "^2.0.1"
+    micromatch "^3.1.10"
+    slash "^2.0.0"
+    stack-utils "^1.0.1"
+
 jest-mock@^23.2.0:
   version "23.2.0"
   resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-23.2.0.tgz#ad1c60f29e8719d47c26e1138098b6d18b261134"
   integrity sha1-rRxg8p6HGdR8JuETgJi20YsmETQ=
+
+jest-mock@^24.7.0:
+  version "24.7.0"
+  resolved "https://registry.yarnpkg.com/jest-mock/-/jest-mock-24.7.0.tgz#e49ce7262c12d7f5897b0d8af77f6db8e538023b"
+  integrity sha512-6taW4B4WUcEiT2V9BbOmwyGuwuAFT2G8yghF7nyNW1/2gq5+6aTqSPcS9lS6ArvEkX55vbPAS/Jarx5LSm4Fng==
+  dependencies:
+    "@jest/types" "^24.7.0"
 
 jest-regex-util@^23.3.0:
   version "23.3.0"
@@ -3555,6 +3647,24 @@ jest-util@^23.4.0:
     slash "^1.0.0"
     source-map "^0.6.0"
 
+jest-util@^24.7.1:
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-24.7.1.tgz#b4043df57b32a23be27c75a2763d8faf242038ff"
+  integrity sha512-/KilOue2n2rZ5AnEBYoxOXkeTu6vi7cjgQ8MXEkih0oeAXT6JkS3fr7/j8+engCjciOU1Nq5loMSKe0A1oeX0A==
+  dependencies:
+    "@jest/console" "^24.7.1"
+    "@jest/fake-timers" "^24.7.1"
+    "@jest/source-map" "^24.3.0"
+    "@jest/test-result" "^24.7.1"
+    "@jest/types" "^24.7.0"
+    callsites "^3.0.0"
+    chalk "^2.0.1"
+    graceful-fs "^4.1.15"
+    is-ci "^2.0.0"
+    mkdirp "^0.5.1"
+    slash "^2.0.0"
+    source-map "^0.6.0"
+
 jest-validate@^23.6.0:
   version "23.6.0"
   resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-23.6.0.tgz#36761f99d1ed33fcd425b4e4c5595d62b6597474"
@@ -3565,6 +3675,18 @@ jest-validate@^23.6.0:
     leven "^2.1.0"
     pretty-format "^23.6.0"
 
+jest-watch-typeahead@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/jest-watch-typeahead/-/jest-watch-typeahead-0.3.0.tgz#f56d9ee17ea71ecbf8253fed213df3185a1584c9"
+  integrity sha512-+uOtlppt9ysST6k6ZTqsPI0WNz2HLa8bowiZylZoQCQaAVn7XsVmHhZREkz73FhKelrFrpne4hQQjdq42nFEmA==
+  dependencies:
+    ansi-escapes "^3.0.0"
+    chalk "^2.4.1"
+    jest-watcher "^24.3.0"
+    slash "^2.0.0"
+    string-length "^2.0.0"
+    strip-ansi "^5.0.0"
+
 jest-watcher@^23.4.0:
   version "23.4.0"
   resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-23.4.0.tgz#d2e28ce74f8dad6c6afc922b92cabef6ed05c91c"
@@ -3572,6 +3694,19 @@ jest-watcher@^23.4.0:
   dependencies:
     ansi-escapes "^3.0.0"
     chalk "^2.0.1"
+    string-length "^2.0.0"
+
+jest-watcher@^24.3.0:
+  version "24.7.1"
+  resolved "https://registry.yarnpkg.com/jest-watcher/-/jest-watcher-24.7.1.tgz#e161363d7f3f4e1ef3d389b7b3a0aad247b673f5"
+  integrity sha512-Wd6TepHLRHVKLNPacEsBwlp9raeBIO+01xrN24Dek4ggTS8HHnOzYSFnvp+6MtkkJ3KfMzy220KTi95e2rRkrw==
+  dependencies:
+    "@jest/test-result" "^24.7.1"
+    "@jest/types" "^24.7.0"
+    "@types/yargs" "^12.0.9"
+    ansi-escapes "^3.0.0"
+    chalk "^2.0.1"
+    jest-util "^24.7.1"
     string-length "^2.0.0"
 
 jest-worker@^23.2.0:


### PR DESCRIPTION
Include [`--ci`](https://jestjs.io/docs/en/cli#ci) flag when `process.env.CI` is `'true'` plus tests.

Also adds [`jest-watch-typeahead`](https://yarnpkg.com/en/package/jest-watch-typeahead) to make file filtering in watch mode easier

Fixes #24 