### PR TITLE
fix: Name bin benmvp

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "module": "lib/esm/index.js",
   "jsnext:main": "lib/esm/index.js",
   "types": "lib/types/index.d.ts",
-  "bin": "bin/benmvp",
+  "bin": {
+    "benmvp": "bin/benmvp"
+  },
   "files": [
     "/lib",
     "/bin"


### PR DESCRIPTION

We weren't giving the bin a name so it was defaulting to the name of the package, which probably doesn't work since it's a scoped package.

Now we're giving an explicit name `benmvp` as the docs outline.