### PR TITLE
fix(command): Remove core-js dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  # - 'node'
+  - 'node'
+  - '12'
   - '10'
   - '8'
 cache: yarn

--- a/package.json
+++ b/package.json
@@ -38,8 +38,10 @@
     "@babel/plugin-external-helpers": "^7.2.0",
     "@babel/plugin-proposal-class-properties": "^7.2.0",
     "@babel/plugin-proposal-object-rest-spread": "^7.2.0",
+    "@babel/plugin-transform-runtime": "^7.4.4",
     "@babel/preset-env": "^7.2.0",
     "@babel/preset-typescript": "^7.1.0",
+    "@babel/runtime": "^7.4.5",
     "@types/jest": "^24.0.11",
     "@typescript-eslint/eslint-plugin": "^1.8.0",
     "@typescript-eslint/parser": "^1.7.0",
@@ -56,7 +58,6 @@
     "jest-runner-tsc": "^1.3.2",
     "jest-watch-typeahead": "^0.3.0",
     "lodash": "^4.17.11",
-    "regenerator-runtime": "^0.13.2",
     "typescript": "^3.2.1",
     "yargs": "^13.1.0"
   },

--- a/src/commands/build/babel-config-utils.js
+++ b/src/commands/build/babel-config-utils.js
@@ -9,10 +9,6 @@ const getBabelConfig = (moduleType) => ({
       {
         targets: 'last 2 versions',
         modules: moduleType === 'esm' ? false : moduleType,
-        useBuiltIns: 'usage',
-        corejs: {
-          version: 3,
-        }
       },
     ],
     '@babel/preset-typescript',
@@ -20,6 +16,15 @@ const getBabelConfig = (moduleType) => ({
   plugins: [
     ['@babel/plugin-proposal-class-properties', {loose: true}],
     '@babel/plugin-proposal-object-rest-spread',
+    ['@babel/plugin-transform-runtime', {
+      corejs: false,
+      helpers: true,
+      regenerator: true,
+
+      // NOTE: May need to point this to a specific one, see
+      // https://github.com/facebook/create-react-app/blob/695ca7576a6d27912bcf9d992b00ef7316232555/packages/babel-preset-react-app/create.js#L181
+      absoluteRuntime: false,
+    }]
   ],
 })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -586,6 +586,16 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-transform-runtime@^7.4.4":
+  version "7.4.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.4.4.tgz#a50f5d16e9c3a4ac18a1a9f9803c107c380bce08"
+  integrity sha512-aMVojEjPszvau3NRg+TIH14ynZLvPewH4xhlCW1w6A3rkxTS1m4uwzRclYR9oS+rl/dr+kT+pzbfHuAWP/lc7Q==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/helper-plugin-utils" "^7.0.0"
+    resolve "^1.8.1"
+    semver "^5.5.1"
+
 "@babel/plugin-transform-shorthand-properties@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.2.0.tgz#6333aee2f8d6ee7e28615457298934a3b46198f0"
@@ -701,6 +711,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-transform-typescript" "^7.3.2"
+
+"@babel/runtime@^7.4.5":
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.4.5.tgz#582bb531f5f9dc67d2fcb682979894f75e253f12"
+  integrity sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
 
 "@babel/template@7.0.0-beta.44":
   version "7.0.0-beta.44"
@@ -4598,6 +4615,13 @@ resolve@^1.5.0:
   integrity sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==
   dependencies:
     path-parse "^1.0.5"
+
+resolve@^1.8.1:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.0.tgz#4014870ba296176b86343d50b60f3b50609ce232"
+  integrity sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==
+  dependencies:
+    path-parse "^1.0.6"
 
 restore-cursor@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
The previous configuration depended on `core-js` for everything ES6+. Instead now, it assumes that the destination library will provide any necessary polyfills.

The only gotcha was the `async`/`await` code. The default Babel transform adds in global `regneratorRuntime` which didn't exist. Making use of [`@babel/plugin-transform-runtime`](https://babeljs.io/docs/en/babel-plugin-transform-runtime) which references `@babel/runtime` module to avoid duplication across compiled output.

NOTE: Also re-enabling Node 12 in the test suite now that `node-gyp` that was failing has been fixed.

Fixes #33