### PR TITLE
feat(command): Fail tests under certain conditions

### DIFF
--- a/src/commands/test/project-unit.js
+++ b/src/commands/test/project-unit.js
@@ -11,6 +11,8 @@ module.exports = {
   // is just looking at *.ts
   testMatch: [resolve(ROOT_DIR, 'src/**/*.spec.ts')],
 
+  setupFilesAfterEnv: [resolve(__dirname, 'unit-setup.js')],
+
   // TODO: Use setupTestFrameworkScriptFile to ensure an expect runs for each test
   // Possibly also prevent console.error / console.warn
 }

--- a/src/commands/test/unit-setup.js
+++ b/src/commands/test/unit-setup.js
@@ -1,0 +1,13 @@
+beforeEach(() => {
+  expect.hasAssertions()
+})
+
+const CONSOLE_FAIL_TYPES = ['error', 'warn']
+
+// Throw errors when a `console.error` or `console.warn` happens
+CONSOLE_FAIL_TYPES.forEach((type) => {
+  // eslint-disable-next-line no-console
+  console[type] = (message) => {
+    throw new Error(`Failing due to console.${type} while running test!\n\n${message}`)
+  }
+})


### PR DESCRIPTION

A unit test will fail when:

- A test case doesn't have any assertions (typically broken async tests)
- A `console.error` or `console.warn` happens during test case run

BREAKING CHANGE: This change is non-backwards since it'll likely create new test failures