### PR TITLE
feat(command): Add --pattern flag for tests

### DIFF
--- a/docs/api/build.md
+++ b/docs/api/build.md
@@ -44,7 +44,7 @@ build({
 })
 ```
 
-## Type
+## Signature
 
 `build()` has the following [TypeScript](https://www.typescriptlang.org/) signature:
 

--- a/docs/api/start.md
+++ b/docs/api/start.md
@@ -6,7 +6,7 @@ Looking for CLI docs? View companion [`benmvp start` documentation](../cli/start
 
 ## Examples
 
-To run all modes (default behavior):
+To continuously run all modes on all files (default behavior):
 
 ```js
 import {start} from '@benmvp/cli'
@@ -14,7 +14,7 @@ import {start} from '@benmvp/cli'
 start()
 ```
 
-To run just type-checking:
+To continuously run just type-checking on all files:
 
 ```js
 import {start} from '@benmvp/cli'
@@ -24,7 +24,7 @@ start({
 })
 ```
 
-To run linting & unit tests:
+To continuously run linting & unit tests on all files:
 
 ```sh
 import {start} from '@benmvp/cli'
@@ -34,12 +34,39 @@ start({
 })
 ```
 
-## Type
+To continuously run all modes only on files within `utils/` directories:
+
+```js
+import {test} from '@benmvp/cli'
+
+start({
+  pattern: 'utils/',
+})
+```
+
+To continuously run just linting on files within `api/` directories:
+
+```js
+import {test} from '@benmvp/cli'
+
+start({
+  modes: ['lint'],
+  pattern: 'api/',
+})
+```
+
+## Signature
 
 `start()` has the following [TypeScript](https://www.typescriptlang.org/) signature:
 
 ```js
-([options]: Options): Promise<Result>
+type Mode = 'type' | 'lint' | 'unit'
+namespace TestOptions {
+  modes: Mode[];
+  pattern: string;
+}
+
+([options]: TestOptions): Promise<Result>
 ```
 
 ## Options
@@ -57,6 +84,12 @@ An `Array` of the types or modes of tests to run. Available modes:
 Optional. Defaults to all modes when unspecified.
 
 > NOTE: [Jest Watch Plugins](https://jestjs.io/docs/en/watch-plugins) are added to make watch mode even more useful. Specifically the [eslint `watch-fix` plugin](https://github.com/jest-community/jest-runner-eslint#toggle---fix-in-watch-mode) is added to enable auto-fixing of lint errors. However, for this to work, `'lint'` has to be the first mode when specified.
+
+### `pattern`
+
+A regexp pattern string that is matched against all tests paths before executing the test.
+
+Optional. Defaults to `''` (signifying no filter)
 
 ## Return Value
 

--- a/docs/api/test.md
+++ b/docs/api/test.md
@@ -8,7 +8,7 @@ Looking for CLI docs? View companion [`benmvp test` documentation](../cli/test.m
 
 ## Examples
 
-To run all modes (default behavior):
+To run all modes on all files (default behavior):
 
 ```js
 import {test} from '@benmvp/cli'
@@ -16,7 +16,7 @@ import {test} from '@benmvp/cli'
 test()
 ```
 
-To run just unit tests:
+To run just unit tests on all files:
 
 ```js
 import {test} from '@benmvp/cli'
@@ -26,27 +26,56 @@ test({
 })
 ```
 
-To run typing & linting:
+To run linting & typing on all files:
 
 ```js
 import {test} from '@benmvp/cli'
 
 test({
-  modes: ['type', 'lint'],
+  modes: ['lint', 'type'],
 })
 ```
 
-## Type
+To run all modes only on files within `utils/` directories:
+
+```js
+import {test} from '@benmvp/cli'
+
+test({
+  pattern: 'utils/',
+})
+```
+
+To just run linting on files within `api/` directories while continuously watching for changes:
+
+```js
+import {test} from '@benmvp/cli'
+
+test({
+  modes: ['lint'],
+  pattern: 'api/',
+  watch: true,
+})
+```
+
+## Signature
 
 `test()` has the following [TypeScript](https://www.typescriptlang.org/) signature:
 
 ```js
-([options]: Options): Promise<Result>
+type Mode = 'type' | 'lint' | 'unit'
+namespace TestOptions {
+  modes: Mode[];
+  pattern: string;
+  watch: boolean;
+}
+
+([options]: TestOptions): Promise<Result>
 ```
 
 ## Options
 
-The optional `Options` object supports the following properties:
+The optional `TestOptions` object supports the following properties:
 
 ### `modes`
 
@@ -57,6 +86,12 @@ An `Array` of the types or modes of tests to run. Available modes:
 - `'unit'` - Runs Jest-based unit tests (files ending in `.spec.ts`)
 
 Optional. Defaults to all modes when unspecified. 
+
+### `pattern`
+
+A regexp pattern string that is matched against all tests paths before executing the test.
+
+Optional. Defaults to `''` (signifying no filter)
 
 ### `watch`
 

--- a/docs/cli/start.md
+++ b/docs/cli/start.md
@@ -8,22 +8,34 @@ Looking for Node API docs? View companion [`start()` documentation](../api/start
 
 ## Examples
 
-To run all modes (default behavior):
+To continuously run all modes on all files (default behavior):
 
 ```sh
 benmvp start
 ```
 
-To run just type-checking:
+To continuously run just type-checking on all files:
 
 ```sh
 benmvp start --modes type
 ```
 
-To run linting & unit tests:
+To continuously run linting & unit tests on all files:
 
 ```sh
 benmvp start --modes lint unit
+```
+
+To continuously run all modes only on files within `utils/` directories:
+
+```sh
+benmvp start --pattern utils/
+```
+
+To continuously run just linting on files within `api/` directories:
+
+```sh
+benmvp start --modes lint --pattern api/
 ```
 
 ## Arguments
@@ -39,6 +51,12 @@ A space-separated list of the types or modes of tests to run. Aliased as `-m`. A
 Optional. Defaults to all modes.
 
 > NOTE: [Jest Watch Plugins](https://jestjs.io/docs/en/watch-plugins) are added to make watch mode even more useful. Specifically the [eslint `watch-fix` plugin](https://github.com/jest-community/jest-runner-eslint#toggle---fix-in-watch-mode) is added to enable auto-fixing of lint errors. However, for this to work, `lint` has to be the first mode when specified.
+
+### `--pattern`
+
+A regexp pattern string that is matched against all tests paths before executing the test. Aliased as `-p`.
+
+Optional. Defaults to `''` (signifying no filter)
 
 ---
 

--- a/docs/cli/test.md
+++ b/docs/cli/test.md
@@ -8,22 +8,34 @@ Looking for Node API docs? View companion [`test()` documentation](../api/test.m
 
 ## Examples
 
-To run all modes (default behavior):
+To run all modes on all files (default behavior):
 
 ```sh
 benmvp test
 ```
 
-To run just unit tests:
+To run just unit tests on all files:
 
 ```sh
 benmvp test --modes unit
 ```
 
-To run typing & linting:
+To run linting & typing on all files:
 
 ```sh
-benmvp start --modes lint type
+benmvp test --modes lint type
+```
+
+To run all modes only on files within `utils/` directories:
+
+```sh
+benmvp test --patern utils/
+```
+
+To just run linting on files within `api/` directories while continuously watching for changes:
+
+```sh
+benmvp test --modes lint --pattern api/ --watch
 ```
 
 ## Arguments
@@ -37,6 +49,12 @@ A space-separated list of the types or modes of tests to run. Aliased as `-m`. A
 - `unit` - Runs Jest-based unit tests (files ending in `.spec.ts`)
 
 Optional. Defaults to all modes.
+
+### `--pattern`
+
+A regexp pattern string that is matched against all tests paths before executing the test. Aliased as `-p`.
+
+Optional. Defaults to `''` (signifying no filter)
 
 ### `--watch`
 

--- a/src/cli/__tests__/index.spec.ts
+++ b/src/cli/__tests__/index.spec.ts
@@ -486,6 +486,7 @@ describe('run', () => {
 
       expect(testCommand).toHaveBeenCalledWith({
         modes: TEST_ARGS.modes.default,
+        pattern: TEST_ARGS.pattern.default,
         watch: TEST_ARGS.watch.default,
       })
     })
@@ -496,6 +497,7 @@ describe('run', () => {
 
         expect(testCommand).toHaveBeenCalledWith({
           modes: ['lint'],
+          pattern: TEST_ARGS.pattern.default,
           watch: TEST_ARGS.watch.default,
         })
       })
@@ -505,6 +507,7 @@ describe('run', () => {
 
         expect(testCommand).toHaveBeenCalledWith({
           modes: ['lint', 'unit'],
+          pattern: TEST_ARGS.pattern.default,
           watch: TEST_ARGS.watch.default,
         })
       })
@@ -512,7 +515,11 @@ describe('run', () => {
       it('parses singular mode (alias)', () => {
         run(['test', '-m', 'type'])
 
-        expect(testCommand).toHaveBeenCalledWith({modes: ['type'], watch: TEST_ARGS.watch.default})
+        expect(testCommand).toHaveBeenCalledWith({
+          modes: ['type'],
+          pattern: TEST_ARGS.pattern.default,
+          watch: TEST_ARGS.watch.default,
+        })
       })
 
       it('parses multiple modes (alias)', () => {
@@ -520,6 +527,31 @@ describe('run', () => {
 
         expect(testCommand).toHaveBeenCalledWith({
           modes: ['lint', 'unit'],
+          pattern: TEST_ARGS.pattern.default,
+          watch: TEST_ARGS.watch.default,
+        })
+      })
+
+      it('parses pattern', () => {
+        const pattern = 'api/'
+
+        run(['test', '--pattern', pattern])
+
+        expect(testCommand).toHaveBeenCalledWith({
+          modes: TEST_ARGS.modes.default,
+          pattern,
+          watch: TEST_ARGS.watch.default,
+        })
+      })
+
+      it('parses pattern (alias)', () => {
+        const pattern = 'api/'
+
+        run(['test', '-p', pattern])
+
+        expect(testCommand).toHaveBeenCalledWith({
+          modes: TEST_ARGS.modes.default,
+          pattern,
           watch: TEST_ARGS.watch.default,
         })
       })
@@ -529,6 +561,7 @@ describe('run', () => {
 
         expect(testCommand).toHaveBeenCalledWith({
           modes: TEST_ARGS.modes.default,
+          pattern: TEST_ARGS.pattern.default,
           watch: true,
         })
       })
@@ -536,19 +569,31 @@ describe('run', () => {
       it('parses watch (alias)', () => {
         run(['test', '-w'])
 
-        expect(testCommand).toHaveBeenCalledWith({modes: TEST_ARGS.modes.default, watch: true})
+        expect(testCommand).toHaveBeenCalledWith({
+          modes: TEST_ARGS.modes.default,
+          pattern: TEST_ARGS.pattern.default,
+          watch: true,
+        })
       })
 
       it('parses all args', () => {
-        run(['test', '--watch', '--modes', 'unit', 'type'])
+        run(['test', '--watch', '--modes', 'unit', 'type', '--pattern', 'utils/'])
 
-        expect(testCommand).toHaveBeenCalledWith({modes: ['unit', 'type'], watch: true})
+        expect(testCommand).toHaveBeenCalledWith({
+          modes: ['unit', 'type'],
+          pattern: 'utils/',
+          watch: true,
+        })
       })
 
       it('parses all args (aliases)', () => {
-        run(['test', '-m', 'type', 'lint', '-w'])
+        run(['test', '-p', 'utils/', '-m', 'type', 'lint', '-w'])
 
-        expect(testCommand).toHaveBeenCalledWith({modes: ['type', 'lint'], watch: true})
+        expect(testCommand).toHaveBeenCalledWith({
+          modes: ['type', 'lint'],
+          pattern: 'utils/',
+          watch: true,
+        })
       })
     })
   })
@@ -563,32 +608,70 @@ describe('run', () => {
     it('defaults args when none are passed', () => {
       run(['start'])
 
-      expect(start).toHaveBeenCalledWith({modes: START_ARGS.modes.default})
+      expect(start).toHaveBeenCalledWith({
+        modes: START_ARGS.modes.default,
+        pattern: START_ARGS.pattern.default,
+      })
     })
 
     describe('start modes', () => {
       it('parses singular mode', () => {
         run(['start', '--modes', 'lint'])
 
-        expect(start).toHaveBeenCalledWith({modes: ['lint']})
+        expect(start).toHaveBeenCalledWith({
+          modes: ['lint'],
+          pattern: START_ARGS.pattern.default,
+        })
       })
 
       it('parses multiple modes', () => {
         run(['start', '--modes', 'lint', 'unit'])
 
-        expect(start).toHaveBeenCalledWith({modes: ['lint', 'unit']})
+        expect(start).toHaveBeenCalledWith({
+          modes: ['lint', 'unit'],
+          pattern: START_ARGS.pattern.default,
+        })
       })
 
       it('parses singular mode (alias)', () => {
         run(['start', '-m', 'type'])
 
-        expect(start).toHaveBeenCalledWith({modes: ['type']})
+        expect(start).toHaveBeenCalledWith({
+          modes: ['type'],
+          pattern: START_ARGS.pattern.default,
+        })
       })
 
       it('parses multiple modes (alias)', () => {
         run(['start', '-m', 'lint', 'unit'])
 
-        expect(start).toHaveBeenCalledWith({modes: ['lint', 'unit']})
+        expect(start).toHaveBeenCalledWith({
+          modes: ['lint', 'unit'],
+          pattern: START_ARGS.pattern.default,
+        })
+      })
+
+
+      it('parses pattern', () => {
+        const pattern = 'api/'
+
+        run(['start', '--pattern', pattern])
+
+        expect(start).toHaveBeenCalledWith({
+          modes: START_ARGS.modes.default,
+          pattern,
+        })
+      })
+
+      it('parses pattern (alias)', () => {
+        const pattern = 'api/'
+
+        run(['start', '-p', pattern])
+
+        expect(start).toHaveBeenCalledWith({
+          modes: START_ARGS.modes.default,
+          pattern,
+        })
       })
     })
   })

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -20,6 +20,14 @@ const TEST_MODES = {
     default: ['lint', 'type', 'unit'] as TestMode[],
   },
 }
+const TEST_PATTERN = {
+  pattern: {
+    describe: 'Regexp pattern string that is matched against all tests paths before executing the test',
+    alias: 'p',
+    string: true,
+    default: '',
+  },
+}
 const BUILD_FORMATS = {
   formats: {
     describe: 'The module formats to build',
@@ -47,6 +55,7 @@ export const CREATE_POS_ARGS = {
 }
 export const TEST_ARGS: CommandOptions = {
   ...TEST_MODES,
+  ...TEST_PATTERN,
   watch: {
     describe: 'Re-run tests when source files change',
     alias: 'w',
@@ -56,6 +65,7 @@ export const TEST_ARGS: CommandOptions = {
 }
 export const START_ARGS: CommandOptions = {
   ...TEST_MODES,
+  ...TEST_PATTERN,
 }
 export const BUILD_ARGS: CommandOptions = {
   ...BUILD_FORMATS,

--- a/src/commands/start/__tests__/index.spec.ts
+++ b/src/commands/start/__tests__/index.spec.ts
@@ -74,4 +74,28 @@ describe('success cases', () => {
       expect(result).toEqual({code: 0})
     })
   })
+
+  describe('pattern', () => {
+    it('calls jest with args and returns success when no pattern is passed', async () => {
+      const result = await start()
+
+      expect(runJest).toHaveBeenCalledWith(expect.not.arrayContaining([
+        '--pattern',
+      ]))
+
+      expect(result).toEqual({code: 0})
+    })
+
+    it('calls jest with args and returns success when pattern flag is passed', async () => {
+      const pattern = 'utils/'
+      const result = await start({pattern})
+
+      expect(runJest).toHaveBeenCalledWith(expect.arrayContaining([
+        '--testPathPattern',
+        pattern,
+      ]))
+
+      expect(result).toEqual({code: 0})
+    })
+  })
 })

--- a/src/commands/start/index.ts
+++ b/src/commands/start/index.ts
@@ -6,9 +6,14 @@ import testCommand from '../test'
  * Runs the specified modes of tests in on-going watch mode during active development
  * @param {Object} [options] The configuration options for running the library
  * @param {Array<TestMode>} [options.modes] List of the types or modes of tests to run
+ * @param {string} [options.pattern]  Regexp pattern string that is matched against all tests paths before executing the test
  * @returns {Promise<Result>} The result of executing the start
  */
-export default ({modes = START_ARGS.modes.default} = {}): Promise<Result> => testCommand({
+export default ({
+  modes = START_ARGS.modes.default,
+  pattern = START_ARGS.pattern.default,
+} = {}): Promise<Result> => testCommand({
   modes,
+  pattern,
   watch: true,
 })

--- a/src/commands/test/__tests__/index.spec.ts
+++ b/src/commands/test/__tests__/index.spec.ts
@@ -75,6 +75,30 @@ describe('success cases', () => {
     })
   })
 
+  describe('pattern', () => {
+    it('calls jest with args and returns success when no pattern is passed', async () => {
+      const result = await testCommand()
+
+      expect(runJest).toHaveBeenCalledWith(expect.not.arrayContaining([
+        '--pattern',
+      ]))
+
+      expect(result).toEqual({code: 0})
+    })
+
+    it('calls jest with args and returns success when pattern flag is passed', async () => {
+      const pattern = 'utils/'
+      const result = await testCommand({pattern})
+
+      expect(runJest).toHaveBeenCalledWith(expect.arrayContaining([
+        '--testPathPattern',
+        pattern,
+      ]))
+
+      expect(result).toEqual({code: 0})
+    })
+  })
+
   describe('watch', () => {
     it('calls jest with args and returns success when no watch flag is passed', async () => {
       const result = await testCommand()

--- a/src/commands/test/__tests__/utils.spec.ts
+++ b/src/commands/test/__tests__/utils.spec.ts
@@ -15,7 +15,7 @@ describe('getJestArgs', () => {
 
     it('throws an error if empty modes are specified', () => {
       const tryGet = (): void => {
-        getJestArgs({modes: [], watch: false})
+        getJestArgs({modes: [], pattern: '', watch: false})
       }
 
       expect(tryGet).toThrow()
@@ -23,7 +23,7 @@ describe('getJestArgs', () => {
 
     it('throws an error if specified mode does not exist', () => {
       const tryGet = (): void => {
-        getJestArgs({modes: [DUMMY_MODE], watch: false})
+        getJestArgs({modes: [DUMMY_MODE], pattern: '', watch: false})
       }
 
       expect(tryGet).toThrow()
@@ -31,14 +31,14 @@ describe('getJestArgs', () => {
 
     it('throws an error if modes has a mix of valid and invalid', () => {
       const tryGet = (): void => {
-        getJestArgs({modes: ['type', DUMMY_MODE], watch: false})
+        getJestArgs({modes: ['type', DUMMY_MODE], pattern: '', watch: false})
       }
 
       expect(tryGet).toThrow()
     })
 
     it('returns single project when single valid mode is specified', () => {
-      const actual = getJestArgs({modes: ['type'], watch: false})
+      const actual = getJestArgs({modes: ['type'], pattern: '', watch: false})
 
       expect(actual).toEqual(expect.arrayContaining([
         '--projects',
@@ -47,7 +47,7 @@ describe('getJestArgs', () => {
     })
 
     it('returns multiple projects when multiple valid modes are specified', () => {
-      const actual = getJestArgs({modes: ['lint', 'unit'], watch: false})
+      const actual = getJestArgs({modes: ['lint', 'unit'], pattern: '', watch: false})
 
       expect(actual).toEqual(expect.arrayContaining([
         '--projects',
@@ -57,15 +57,33 @@ describe('getJestArgs', () => {
     })
   })
 
+  describe('pattern', () => {
+    it('includes --testPathPattern flag when pattern option is specified', () => {
+      const pattern = 'api/'
+      const actual = getJestArgs({pattern, modes: ['lint'], watch: false})
+
+      expect(actual).toEqual(expect.arrayContaining([
+        '--testPathPattern',
+        pattern,
+      ]))
+    })
+
+    it('does not include --testPathPattern flag when pattern option is empty string', () => {
+      const actual = getJestArgs({pattern: '', modes: ['lint'], watch: false})
+
+      expect(actual).not.toContain('--testPathPattern')
+    })
+  })
+
   describe('watch', () => {
     it('includes --watch flag when watch option is specified as true', () => {
-      const actual = getJestArgs({watch: true, modes: ['unit']})
+      const actual = getJestArgs({watch: true, modes: ['unit'], pattern: ''})
 
       expect(actual).toContain('--watch')
     })
 
     it('does not include --watch flag when watch option is specified as false', () => {
-      const actual = getJestArgs({watch: false, modes: ['unit']})
+      const actual = getJestArgs({watch: false, modes: ['unit'], pattern: ''})
 
       expect(actual).not.toContain('--watch')
     })
@@ -77,7 +95,7 @@ describe('getJestArgs', () => {
 
       process.env.CI = 'true'
 
-      const actual = getJestArgs({modes: ['unit'], watch: false})
+      const actual = getJestArgs({modes: ['unit'], pattern: '', watch: false})
 
       expect(actual).toContain('--ci')
 
@@ -89,7 +107,7 @@ describe('getJestArgs', () => {
 
       process.env.CI = 'false'
 
-      const actual = getJestArgs({modes: ['unit'], watch: false})
+      const actual = getJestArgs({modes: ['unit'], pattern: '', watch: false})
 
       expect(actual).not.toContain('--ci')
 

--- a/src/commands/test/index.ts
+++ b/src/commands/test/index.ts
@@ -7,15 +7,17 @@ import runJest from './run-jest'
  * Runs a one-time pass of the specified modes of tests
  * @param {Object} [options] The configuration options for testing the library
  * @param {Array<TestMode>} [options.modes] List of the types or modes of tests to run
+ * @param {string} [options.pattern]  Regexp pattern string that is matched against all tests paths before executing the test
  * @param {boolean} [options.watch] Whether or not to re-run tests as source files change
  * @returns {Promise<Result>} The result of executing the test
  */
 export default async ({
   modes = TEST_ARGS.modes.default,
+  pattern = TEST_ARGS.pattern.default,
   watch = TEST_ARGS.watch.default,
 } = {}): Promise<Result> => {
   try {
-    await runJest(getJestArgs({modes, watch}))
+    await runJest(getJestArgs({modes, pattern, watch}))
   } catch (error) {
     return {
       code: 1,

--- a/src/commands/test/utils.ts
+++ b/src/commands/test/utils.ts
@@ -9,6 +9,7 @@ interface ValidTestModes {
 }
 export interface Args {
   modes: TestMode[];
+  pattern: string;
   watch: boolean;
 }
 
@@ -26,11 +27,16 @@ const VALID_TEST_MODES: ValidTestModes = {
  * Retrieves the arguments to pass to Jest based on the specified options
  * @param {Object} options The configuration options for testing the library
  * @param {Array<TestMode>} options.modes List of the types or modes of tests to run
+ * @param {string} options.pattern  Regexp pattern string that is matched against all tests paths before executing the test
  * @param {boolean} options.watch Whether or not to re-run tests as source files change
  * @returns {Array<string>} The array of arguments
  */
-export const getJestArgs = ({modes, watch}: Args): string[] => {
+export const getJestArgs = ({modes, pattern, watch}: Args): string[] => {
   let jestArgs = [] as string[]
+
+  if (pattern) {
+    jestArgs = [...jestArgs, '--testPathPattern', pattern]
+  }
 
   if (watch) {
     jestArgs = [...jestArgs, '--watch']


### PR DESCRIPTION

With the `--pattern` flag available for the `test` and `start` commands, we can filter down which tests are being run. This is particularly useful when running tests in watch mode. This is probably more realistic than running `benmvp start` on the whole source code.