### PR TITLE
fix(command): Fix install of @benmvp/cli w/ integrate

### DIFF
--- a/src/commands/integrate/run.sh
+++ b/src/commands/integrate/run.sh
@@ -30,7 +30,7 @@ pushd $TEMP_INTEGRATION_PATH
 # Note for integration tests for @benmvp/cli specifically this *should* overwrite
 # @benmvp/cli dependency from registry with the tarball
 echo -e "npm install && npm install --save-dev @benmvp/cli $TARBALL_FILE_PATH\n"
-npm install && npm install --save-dev $TARBALL_FILE_PATH
+npm install && npm install --save-dev @benmvp/cli $TARBALL_FILE_PATH
 
 # Verify node modules were installed
 if [ ! -d "$TEMP_INTEGRATION_PATH/node_modules" ]; then


### PR DESCRIPTION

The intention with 555a184 was to install `@benmvp/cli` as a dev dependency in the integration tests project, but I just updated the `echo` string now the actual command. 🤦🏾‍♂️

Verified this in `url-lib` by running `npm pack` in this repo and manually installing it in `url-lib` and running its integration tests. 🤞🏾