### PR TITLE
fix(command): Build before integrate

### DIFF
--- a/docs/api/integrate.md
+++ b/docs/api/integrate.md
@@ -8,7 +8,7 @@ The integration tests generally are run in your continuous integration (CI) envi
 
 The integration test process is as follows:
 
-1. [`npm pack`](https://docs.npmjs.com/cli/pack.html) the library to create the _same_ `.tgz` tarball that would be published in the registry
+1. [`npm pack`](https://docs.npmjs.com/cli/pack.html) the built library to create the _same_ `.tgz` tarball that would be published in the registry
 1. Copy the integration tests "project" at `integration-tests/` over to a temporary directory
 1. `npm install` the packed library (from Step 1), `@benmvp/cli`, and any other dependencies specified in the `package.json` of the project
 1. Run `npx benmvp test` on the project to use `@benmvp/cli` to run the tests

--- a/docs/cli/integrate.md
+++ b/docs/cli/integrate.md
@@ -8,7 +8,7 @@ The integration tests generally are run in your continuous integration (CI) envi
 
 The integration test process is as follows:
 
-1. [`npm pack`](https://docs.npmjs.com/cli/pack.html) the library to create the _same_ `.tgz` tarball that would be published in the registry
+1. [`npm pack`](https://docs.npmjs.com/cli/pack.html) the built library to create the _same_ `.tgz` tarball that would be published in the registry
 1. Copy the integration tests "project" at `integration-tests/` over to a temporary directory
 1. `npm install` the packed library (from Step 1), `@benmvp/cli`, and any other dependencies specified in the `package.json` of the project
 1. Run `npx benmvp test` on the project to use `@benmvp/cli` to run the tests

--- a/src/commands/integrate/run.sh
+++ b/src/commands/integrate/run.sh
@@ -9,6 +9,12 @@ echo -e "Created temp integration path: $TEMP_INTEGRATION_PATH\n"
 
 TARBALL_FILE_PATH="$TEMP_INTEGRATION_PATH/test-package.tgz"
 
+# build library before packing in order to be able to reference built files
+# this step will fail within benmvp-cli repo since the `benmvp` bin doesn't
+# exist yet, but that's ok because we always `build` before `integrate`
+echo -e "npx benmvp build\n"
+npx benmvp build
+
 # npm pack to tarball library into integration directory
 echo -e "npm pack && mv *.tgz $TARBALL_FILE_PATH\n"
 npm pack && mv *.tgz $TARBALL_FILE_PATH
@@ -40,7 +46,7 @@ if [ ! -d "$TEMP_INTEGRATION_PATH/node_modules" ]; then
   exit 1
 fi
 
-# Run `npx benmvp test` in $tempIntegration to use @benmvp/cli
+# Run `npx benmvp test` in $TEMP_INTEGRATION_PATH to use @benmvp/cli
 # to run the integration tests
 # NOTE: For integration test *for* @benmvp/cli this will use the .tgz version
 # that would've been added above


### PR DESCRIPTION

We need to `build` the library before calling `npm pack` to ensure it has the latest built assets, which will then be used by the integration tests project.

Didn't catch this case when running the integration tests for @benmvp/cli itself because we always `build` before running all of the scripts.