### PR TITLE
fix(command): Inline Babel helpers with build

### DIFF
--- a/src/commands/build/babel-config-utils.js
+++ b/src/commands/build/babel-config-utils.js
@@ -18,7 +18,7 @@ const getBabelConfig = (moduleType) => ({
     '@babel/plugin-proposal-object-rest-spread',
     ['@babel/plugin-transform-runtime', {
       corejs: false,
-      helpers: true,
+      helpers: false,
       regenerator: true,
 
       // NOTE: May need to point this to a specific one, see


### PR DESCRIPTION

When the helpers were not inlined they depended on `@babel/runtime` which was fine for this package, but for the packages uses `@benmvp/cli` they would also depend on `@babel/runtime`, which is not desired.

So now those helpers are just inlined and duplicated. For now if a lib wants to use `async` they'll need to manually include the `regeneratorRuntime`.