### PR TITLE
feature: Add prettier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,23 +12,56 @@ jobs:
         node: [8, 10, 12, 13]
 
     steps:
-    - name: Checkout repo
-      uses: actions/checkout@v1
+      - name: Checkout repo
+        uses: actions/checkout@v1
 
-    - name: Use Node ${{ matrix.node }}
-      uses: actions/setup-node@v1
-      with:
-        node-version: ${{ matrix.node }}
+      - name: Use Node ${{ matrix.node }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node }}
 
-    - name: Install NPM dependencies
-      run: npm ci
+      - name: Install NPM dependencies
+        run: npm ci
 
-    - name: Run unit tests
-      run: npm test
-      env:
-        CI: true
+      - name: Run unit tests
+        run: npm test
+        env:
+          CI: true
 
-    - name: Run integration tests
-      run: npm run integrate
-      env:
-        CI: true
+      - name: Run integration tests
+        run: npm run integrate
+        env:
+          CI: true
+
+  prettier:
+    name: Format Files
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v1
+
+      - name: Use Node12
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+
+      - name: Install NPM dependencies
+        run: npm ci
+
+      - name: Format Files
+        run: npm run format
+
+      - name: Show git working tree
+        run: git status
+
+      - name: Commit formatted Files
+        run: |
+          git add -A
+          # Do nothing if there are no changes
+          git diff-index --quiet HEAD || git commit -m "Automated format of files"
+
+      - name: Push data to repo
+        uses: ad-m/github-push-action@v0.5.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,14 +49,16 @@ jobs:
       - name: Install NPM dependencies
         run: npm ci
 
-      - name: Format Files
+      - name: Format iles
         run: npm run format
 
       - name: Show git working tree
         run: git status
 
-      - name: Commit formatted Files
+      - name: Commit formatted files on branch
         run: |
+          git config --local user.email "ben@benmvp.com"
+          git config --local user.name "Automated Formatter"
           git add -A
           # Do nothing if there are no changes
           git diff-index --quiet HEAD || git commit -m "Automated format of files"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,5 +66,8 @@ jobs:
       - name: Push data to repo
         uses: ad-m/github-push-action@v0.5.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: ${{ github.ref }}
+
+          # Need to use special repo-scoped token so that when
+          # the push happens, it triggers CI again
+          github_token: ${{ secrets.REPO_SCOPED_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v1
 
-      - name: Use Node12
+      - name: Use Node 12
         uses: actions/setup-node@v1
         with:
           node-version: 12
@@ -49,7 +49,7 @@ jobs:
       - name: Install NPM dependencies
         run: npm ci
 
-      - name: Format iles
+      - name: Format files
         run: npm run format
 
       - name: Show git working tree
@@ -67,3 +67,4 @@ jobs:
         uses: ad-m/github-push-action@v0.5.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: npm ci
 
       - name: Format files
-        run: npx prettier --write '**/*.*'"
+        run: npx prettier --write "**/*.*"
 
       - name: Show git working tree
         run: git status

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         run: npm ci
 
       - name: Format files
-        run: npm run format
+        run: npx prettier --write '**/*.*'"
 
       - name: Show git working tree
         run: git status

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,13 @@
+# Ignore dotfiles
+**/.*
+
+# Ignore other extensions prettier doesn't know about
+**/*.sh
+**/*.log
+
+# Ignore NPM files
+**/package.json
+**/package-lock.json
+
+# Ignore all built files
+lib/**/*.*

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,13 +1,6 @@
 {
-  "printWidth": 80,
-  "tabWidth": 2,
-  "useTabs": false,
   "semi": false,
   "singleQuote": true,
-  "quoteProps": "as-needed",
-  "jsxSingleQuote": false,
   "trailingComma": "all",
-  "bracketSpacing": true,
-  "jsxBracketSameLine": false,
   "arrowParens": "always"
 }

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,13 @@
+{
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": false,
+  "singleQuote": true,
+  "quoteProps": "as-needed",
+  "jsxSingleQuote": false,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "jsxBracketSameLine": false,
+  "arrowParens": "always"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,11 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.formatOnSave": true
+  "[json]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "editor.formatOnSave": true,
+  "json.format.enable": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,4 @@
 {
-  "jest.enableInlineErrorMessages": false,
-  "jest.enableSnapshotPreviews": false,
-  "jest.enableSnapshotUpdateMessages": false,
-  "jest.autoEnable": false
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.formatOnSave": true
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,12 +4,12 @@ Thank you for your interest in contributing to my CLI!
 
 ## Table of Contents
 
-* [Setup](#setup)
-* [Branches](#using-branches-to-submit-changes)
-* [Keeping up to date](#keeping-your-local-repo-up-to-date)
-* [Creating issues](#creating-issues)
-* [Working on and submitting changes](#working-on-and-submitting-changes)
-* [Steps to submit](#steps-to-submit)
+- [Setup](#setup)
+- [Branches](#using-branches-to-submit-changes)
+- [Keeping up to date](#keeping-your-local-repo-up-to-date)
+- [Creating issues](#creating-issues)
+- [Working on and submitting changes](#working-on-and-submitting-changes)
+- [Steps to submit](#steps-to-submit)
 
 ## Setup
 
@@ -61,4 +61,4 @@ Please try to conform to the coding style of the code base.
 1. Check to make sure that your changes are documented properly (inline comments for interesting lines, READMEs, etc.)
 1. Run `npm test` to ensure that all tests pass, the linter is satisfied and your changes are typescript compliant.
 1. PR titles must be prefixed by the type of changes the PR contains followed by the scope of what the PR touches. We are following the [angular commit guidelines](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines). Please use one of `feat, fix, docs, style, refactor, perf, test, chore` as the prefix. The " is the the direct product your changes affect. Example: `chore(build): Add encrypted ssh key for semantic-release` because its a chore and it touches the build. For multiple scope items, you can comma separate 2 or 3 but if there are more than that please use a `*` instead.
-1.  Please use a [closing issue keyword](https://help.github.com/articles/closing-issues-using-keywords/) to indicate the issue that your fix addresses in the description section of the pull request template. Example: `fixes #32` to close issue #32
+1. Please use a [closing issue keyword](https://help.github.com/articles/closing-issues-using-keywords/) to indicate the issue that your fix addresses in the description section of the pull request template. Example: `fixes #32` to close issue #32

--- a/README.md
+++ b/README.md
@@ -22,14 +22,14 @@ A highly-opinionated, zero-config CLI for consistent infra for Ben Ilegbodu's Ty
 
 ## ToC
 
-*  [Installation](#installation)
-*  [Quick Usage](#quick-usage)
-*  [Docs](docs/)
-*  [Supported Node Versions](#supported-node-versions)
-*  [Technologies Used](#technologies-used)
-*  [Contributing](CONTRIBUTING.md)
-*  [Project philosophy](#project-philosophy)
-*  [License](LICENSE)
+- [Installation](#installation)
+- [Quick Usage](#quick-usage)
+- [Docs](docs/)
+- [Supported Node Versions](#supported-node-versions)
+- [Technologies Used](#technologies-used)
+- [Contributing](CONTRIBUTING.md)
+- [Project philosophy](#project-philosophy)
+- [License](LICENSE)
 
 ## Installation
 

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -8,4 +8,3 @@ The Node API exposes the following functions:
 - [`build()`](build.md) - Builds the library into the desired module formats at the specified location
 - [`integrate()`](integrate.md) - Runs additional integration tests for the library
 - [`run()`](run.md) - Parses the specified array of CLI arguments to runs the desired command
-

--- a/docs/api/build.md
+++ b/docs/api/build.md
@@ -9,7 +9,7 @@ Looking for CLI docs? View companion [`benmvp build` documentation](../cli/build
 Build all module formats in default output directory:
 
 ```js
-import {build} from '@benmvp/cli'
+import { build } from '@benmvp/cli'
 
 build()
 ```
@@ -17,15 +17,15 @@ build()
 To specify an alternate output directory:
 
 ```js
-import {build} from '@benmvp/cli'
+import { build } from '@benmvp/cli'
 
-build({out: './built'})
+build({ out: './built' })
 ```
 
 To exclude type definitions:
 
 ```js
-import {build} from '@benmvp/cli'
+import { build } from '@benmvp/cli'
 
 build({
   formats: ['esm', 'cjs'],
@@ -35,7 +35,7 @@ build({
 To put ESM & type declarations in an alternate build location with continuous watch:
 
 ```js
-import {build} from '@benmvp/cli'
+import { build } from '@benmvp/cli'
 
 build({
   formats: ['esm', 'type'],

--- a/docs/api/create.md
+++ b/docs/api/create.md
@@ -4,9 +4,13 @@
 
 Creates a new library with the specified name set up with infrastructure using `@benmvp/cli`, returning a `Promise` indicating whether the creation succeeded or failed.
 
+It will:
+
 - Add `"test"`, `"start"`, `"build"` and `"integrate"` scripts in the `package.json` to call [`benmvp test`](test.md), [`benmvp start`](start.md), [`benmvp build`](build.md), and [`benmvp integrate`](integrate.md), respectively
 - After the `package.json` is created (or updated), it will install `@benmvp/cli` as a dev dependency, using [Yarn](https://yarnpkg.com/) if available. If Yarn is unavailable, it will fallback to [npm](https://docs.npmjs.com/)
-- Will add (or overwrite) a `.travis.yml` file w/ [build stages](https://docs.travis-ci.com/user/build-stages/) for testing and deploying the library
+- Add (or overwrite) `.prettierrc.json`, `.prettierignore` & `.vscode/settings.json` files to format all code
+- Add (or overwrite) a `.github/workflows/ci.yml` [Github workflow](https://help.github.com/en/actions) for testing & formatting your code when a branch is pushed to or a PR is updated. Formatted code will be pushed as a new commit to the branch.
+- Add (or overwrite) a `.github/workflows/release.yml` [Github workflow](https://help.github.com/en/actions) for release a new version of your package with new commits to `master`.
 
 Looking for CLI docs? View companion [`benmvp create` documentation](../cli/create.md).
 

--- a/docs/api/create.md
+++ b/docs/api/create.md
@@ -2,7 +2,6 @@
 
 > NOTE: `create()` is still under development
 
-
 Creates a new library with the specified name set up with infrastructure using `@benmvp/cli`, returning a `Promise` indicating whether the creation succeeded or failed.
 
 - Add `"test"`, `"start"`, `"build"` and `"integrate"` scripts in the `package.json` to call [`benmvp test`](test.md), [`benmvp start`](start.md), [`benmvp build`](build.md), and [`benmvp integrate`](integrate.md), respectively
@@ -16,15 +15,15 @@ Looking for CLI docs? View companion [`benmvp create` documentation](../cli/crea
 Create a new lib named `lib-of-fun` with the default settings (simplest setup):
 
 ```js
-import {create} from '@benmvp/cli'
+import { create } from '@benmvp/cli'
 
-create({name: 'lib-of-fun'})
+create({ name: 'lib-of-fun' })
 ```
 
 Add lint verification to an existing library:
 
 ```js
-import {create} from '@benmvp/cli'
+import { create } from '@benmvp/cli'
 
 create({
   modes: ['lint'],
@@ -34,7 +33,7 @@ create({
 Create a new library named `my-lib` that only outputs ESM format:
 
 ```js
-import {create} from '@benmvp/cli'
+import { create } from '@benmvp/cli'
 
 create({
   name: 'my-lib',
@@ -45,7 +44,7 @@ create({
 Add custom setup to an existing library:
 
 ```js
-import {create} from '@benmvp/cli'
+import { create } from '@benmvp/cli'
 
 create({
   modes: ['type', 'spec'],
@@ -71,10 +70,12 @@ The optional `Options` object supports the following properties:
 The name of the library to create or update.
 
 When `name` is unspecified:
+
 - If a `package.json` does not already exist, it creates a new `package.json` with the name matching the directory it's within.
 - If a `package.json` does exist, it does nothing to the existing `package.json`.
 
 When `name` is specified:
+
 - If a `package.json` does not already exist, it creates a new `package.json` with the specified name.
 - If a `package.json` does exist, it updates the `"name"` property of the `package.json` with specified name.
 
@@ -111,7 +112,6 @@ An `Array` of the types or modes of tests to run. Available modes:
 Optional. Defaults to all modes when unspecified.
 
 This will initialize the `"start"`, `"test"` and `"integrate"` scripts in the `package.json` to pass the matching argument.
-
 
 ## Return Value
 

--- a/docs/api/integrate.md
+++ b/docs/api/integrate.md
@@ -20,7 +20,7 @@ Looking for CLI docs? View companion [`benmvp integrate` documentation](../cli/i
 To run all modes of integration tests on all files (default behavior):
 
 ```js
-import {integrate} from '@benmvp/cli'
+import { integrate } from '@benmvp/cli'
 
 integrate()
 ```
@@ -28,7 +28,7 @@ integrate()
 To run just the integration tests themselves (excluding linting & typing) on all files:
 
 ```js
-import {integrate} from '@benmvp/cli'
+import { integrate } from '@benmvp/cli'
 
 integrate({
   modes: ['spec'],
@@ -38,7 +38,7 @@ integrate({
 To run just linting & typing on all files in the integration tests project:
 
 ```js
-import {integrate} from '@benmvp/cli'
+import { integrate } from '@benmvp/cli'
 
 integrate({
   modes: ['lint', 'type'],
@@ -48,7 +48,7 @@ integrate({
 To run all modes only on files within `utils/` directories of the integration tests project:
 
 ```js
-import {integrate} from '@benmvp/cli'
+import { integrate } from '@benmvp/cli'
 
 integrate({
   pattern: 'utils/',
@@ -58,7 +58,7 @@ integrate({
 To just run linting on files within `api/` directories of the integration tests project:
 
 ```js
-import {integrate} from '@benmvp/cli'
+import { integrate } from '@benmvp/cli'
 
 integrate({
   modes: ['lint'],
@@ -92,7 +92,7 @@ An `Array` of the types or modes of tests to run. Available modes:
 - `'type'` - Runs Typescript type-checking (files ending in `.ts` or `.tsx`)
 - `'lint'` - Runs ESLint (files ending in `.ts` or `.tsx`)
 
-Optional. Defaults to all modes when unspecified. 
+Optional. Defaults to all modes when unspecified.
 
 ### `pattern`
 

--- a/docs/api/run.md
+++ b/docs/api/run.md
@@ -11,7 +11,7 @@ This function is most useful if you have a Node script that accepts parameters t
 Pass along the arguments from a Node script:
 
 ```js
-const {run} = require('@benmvp/cli');
+const { run } = require('@benmvp/cli')
 
 run(process.argv.slice(2))
 ```
@@ -19,7 +19,7 @@ run(process.argv.slice(2))
 Build with specified formats:
 
 ```js
-const {run} = require('@benmvp/cli');
+const { run } = require('@benmvp/cli')
 
 run(['build', '--formats', 'esm', 'cjs'])
 ```
@@ -27,7 +27,7 @@ run(['build', '--formats', 'esm', 'cjs'])
 To run just unit tests:
 
 ```js
-const {run} = require('@benmvp/cli');
+const { run } = require('@benmvp/cli')
 
 run(['test', '--modes', 'spec'])
 ```

--- a/docs/api/start.md
+++ b/docs/api/start.md
@@ -9,7 +9,7 @@ Looking for CLI docs? View companion [`benmvp start` documentation](../cli/start
 To continuously run all modes on all files (default behavior):
 
 ```js
-import {start} from '@benmvp/cli'
+import { start } from '@benmvp/cli'
 
 start()
 ```
@@ -17,10 +17,10 @@ start()
 To continuously run just type-checking on all files:
 
 ```js
-import {start} from '@benmvp/cli'
+import { start } from '@benmvp/cli'
 
 start({
-  modes: ['type']
+  modes: ['type'],
 })
 ```
 
@@ -37,7 +37,7 @@ start({
 To continuously run all modes only on files within `utils/` directories:
 
 ```js
-import {test} from '@benmvp/cli'
+import { test } from '@benmvp/cli'
 
 start({
   pattern: 'utils/',
@@ -47,7 +47,7 @@ start({
 To continuously run just linting on files within `api/` directories:
 
 ```js
-import {test} from '@benmvp/cli'
+import { test } from '@benmvp/cli'
 
 start({
   modes: ['lint'],

--- a/docs/api/test.md
+++ b/docs/api/test.md
@@ -11,7 +11,7 @@ Looking for CLI docs? View companion [`benmvp test` documentation](../cli/test.m
 To run all modes on all files (default behavior):
 
 ```js
-import {test} from '@benmvp/cli'
+import { test } from '@benmvp/cli'
 
 test()
 ```
@@ -19,7 +19,7 @@ test()
 To run just unit tests on all files:
 
 ```js
-import {test} from '@benmvp/cli'
+import { test } from '@benmvp/cli'
 
 test({
   modes: ['spec'],
@@ -29,7 +29,7 @@ test({
 To run linting & typing on all files:
 
 ```js
-import {test} from '@benmvp/cli'
+import { test } from '@benmvp/cli'
 
 test({
   modes: ['lint', 'type'],
@@ -39,7 +39,7 @@ test({
 To run all modes only on files within `utils/` directories:
 
 ```js
-import {test} from '@benmvp/cli'
+import { test } from '@benmvp/cli'
 
 test({
   pattern: 'utils/',
@@ -49,7 +49,7 @@ test({
 To just run linting on files within `api/` directories while continuously watching for changes:
 
 ```js
-import {test} from '@benmvp/cli'
+import { test } from '@benmvp/cli'
 
 test({
   modes: ['lint'],
@@ -85,7 +85,7 @@ An `Array` of the types or modes of tests to run. Available modes:
 - `'lint'` - Runs ESLint (files ending in `.ts` or `.tsx`)
 - `'spec'` - Runs Jest-based unit tests (files ending in `.spec.ts`)
 
-Optional. Defaults to all modes when unspecified. 
+Optional. Defaults to all modes when unspecified.
 
 ### `pattern`
 

--- a/docs/cli/create.md
+++ b/docs/cli/create.md
@@ -8,7 +8,9 @@ It will:
 
 - Add `"test"`, `"start"`, `"build"` and `"integrate"` scripts in the `package.json` to call [`benmvp test`](test.md), [`benmvp start`](start.md), [`benmvp build`](build.md), and [`benmvp integrate`](integrate.md), respectively
 - After the `package.json` is created (or updated), it will install `@benmvp/cli` as a dev dependency, using [Yarn](https://yarnpkg.com/) if available. If Yarn is unavailable, it will fallback to [npm](https://docs.npmjs.com/)
-- Will add (or overwrite) a `.travis.yml` file w/ [build stages](https://docs.travis-ci.com/user/build-stages/) for testing and deploying the library
+- Add (or overwrite) `.prettierrc.json`, `.prettierignore` & `.vscode/settings.json` files to format all code
+- Add (or overwrite) a `.github/workflows/ci.yml` [Github workflow](https://help.github.com/en/actions) for testing & formatting your code when a branch is pushed to or a PR is updated. Formatted code will be pushed as a new commit to the branch.
+- Add (or overwrite) a `.github/workflows/release.yml` [Github workflow](https://help.github.com/en/actions) for release a new version of your package with new commits to `master`.
 
 Looking for Node API docs? View companion [`create()` documentation](../api/create.md).
 

--- a/docs/cli/create.md
+++ b/docs/cli/create.md
@@ -2,7 +2,7 @@
 
 > NOTE: `benmvp create` is still under development
 
-Creates a new library set up with infrastructure using `@benmvp/cli`. 
+Creates a new library set up with infrastructure using `@benmvp/cli`.
 
 It will:
 
@@ -47,10 +47,12 @@ npx @benmvp/cli create --modes type spec --out ./built --formats esm cjs
 (Optional) The name of the library to create or update.
 
 When `name` is unspecified:
+
 - If a `package.json` does not already exist, it creates a new `package.json` with the name matching the directory it's within.
 - If a `package.json` does exist, it does nothing to the existing `package.json`.
 
 When `name` is specified:
+
 - If a `package.json` does not already exist, it creates a new `package.json` with the specified name.
 - If a `package.json` does exist, it updates the `"name"` property of the `package.json` with specified name.
 
@@ -84,7 +86,7 @@ A space-separated list of the types or modes of tests to run. Aliased as `-m`. A
 - `lint` - Runs ESLint
 - `spec` - Runs Jest-based tests
 
-Optional. Defaults to all modes. 
+Optional. Defaults to all modes.
 
 This will initialize the `"start"`, `"test"` and `"integrate"` scripts in the `package.json` to pass the matching argument.
 

--- a/docs/cli/start.md
+++ b/docs/cli/start.md
@@ -1,6 +1,6 @@
 # `benmvp start` Documentation
 
-Runs the library's tests in on-going watch mode during active development. 
+Runs the library's tests in on-going watch mode during active development.
 
 When building a library, the best way to validate that it is working is by type-checking and running tests. Having the type-checking and tests running in watch mode make it easier to continuously ensure that new code is correct and refactors are non-breaking.
 

--- a/integration-tests/src/__tests__/build.spec.ts
+++ b/integration-tests/src/__tests__/build.spec.ts
@@ -19,33 +19,61 @@ describe('when no arguments are passed', () => {
 
   it('transpiles .ts(x) files', async () => {
     expect(await pathExists(resolve(CWD, 'lib/cjs/index.js'))).toBe(true)
-    expect(await pathExists(resolve(CWD, 'lib/cjs/objects/animal.js'))).toBe(true)
-    expect(await pathExists(resolve(CWD, 'lib/cjs/objects/horse.js'))).toBe(true)
-    expect(await pathExists(resolve(CWD, 'lib/cjs/objects/snake.js'))).toBe(true)
-    expect(await pathExists(resolve(CWD, 'lib/cjs/react/Counter.js'))).toBe(true)
+    expect(await pathExists(resolve(CWD, 'lib/cjs/objects/animal.js'))).toBe(
+      true,
+    )
+    expect(await pathExists(resolve(CWD, 'lib/cjs/objects/horse.js'))).toBe(
+      true,
+    )
+    expect(await pathExists(resolve(CWD, 'lib/cjs/objects/snake.js'))).toBe(
+      true,
+    )
+    expect(await pathExists(resolve(CWD, 'lib/cjs/react/Counter.js'))).toBe(
+      true,
+    )
     expect(await pathExists(resolve(CWD, 'lib/cjs/react/Button.js'))).toBe(true)
 
     expect(await pathExists(resolve(CWD, 'lib/esm/index.js'))).toBe(true)
-    expect(await pathExists(resolve(CWD, 'lib/esm/objects/animal.js'))).toBe(true)
-    expect(await pathExists(resolve(CWD, 'lib/esm/objects/horse.js'))).toBe(true)
-    expect(await pathExists(resolve(CWD, 'lib/esm/objects/snake.js'))).toBe(true)
-    expect(await pathExists(resolve(CWD, 'lib/esm/react/Counter.js'))).toBe(true)
+    expect(await pathExists(resolve(CWD, 'lib/esm/objects/animal.js'))).toBe(
+      true,
+    )
+    expect(await pathExists(resolve(CWD, 'lib/esm/objects/horse.js'))).toBe(
+      true,
+    )
+    expect(await pathExists(resolve(CWD, 'lib/esm/objects/snake.js'))).toBe(
+      true,
+    )
+    expect(await pathExists(resolve(CWD, 'lib/esm/react/Counter.js'))).toBe(
+      true,
+    )
     expect(await pathExists(resolve(CWD, 'lib/esm/react/Button.js'))).toBe(true)
   })
   it('generates typescript definitions', async () => {
     expect(await pathExists(resolve(CWD, 'lib/types/index.d.ts'))).toBe(true)
-    expect(await pathExists(resolve(CWD, 'lib/types/objects/animal.d.ts'))).toBe(true)
-    expect(await pathExists(resolve(CWD, 'lib/types/objects/horse.d.ts'))).toBe(true)
-    expect(await pathExists(resolve(CWD, 'lib/types/objects/snake.d.ts'))).toBe(true)
-    expect(await pathExists(resolve(CWD, 'lib/types/react/Counter.d.ts'))).toBe(true)
-    expect(await pathExists(resolve(CWD, 'lib/types/react/Button.d.ts'))).toBe(true)
+    expect(
+      await pathExists(resolve(CWD, 'lib/types/objects/animal.d.ts')),
+    ).toBe(true)
+    expect(await pathExists(resolve(CWD, 'lib/types/objects/horse.d.ts'))).toBe(
+      true,
+    )
+    expect(await pathExists(resolve(CWD, 'lib/types/objects/snake.d.ts'))).toBe(
+      true,
+    )
+    expect(await pathExists(resolve(CWD, 'lib/types/react/Counter.d.ts'))).toBe(
+      true,
+    )
+    expect(await pathExists(resolve(CWD, 'lib/types/react/Button.d.ts'))).toBe(
+      true,
+    )
   })
   it('copies .js files', async () => {
     expect(await pathExists(resolve(CWD, 'lib/cjs/config.js'))).toBe(true)
     expect(await pathExists(resolve(CWD, 'lib/esm/config.js'))).toBe(true)
   })
   it('removes test files', async () => {
-    expect(await pathExists(resolve(CWD, 'lib/esm/__tests__/build.spec.js'))).toBe(false)
+    expect(
+      await pathExists(resolve(CWD, 'lib/esm/__tests__/build.spec.js')),
+    ).toBe(false)
   })
   it('fully transpiles to CJS target', async () => {
     const cjsFile = await readFile(resolve(CWD, 'lib/cjs/index.js'), 'utf8')
@@ -81,32 +109,66 @@ describe('when format & output directory are specified', () => {
   it('transpiles .ts files into specified output folder', async () => {
     expect(await pathExists(resolve(CWD, 'built/esm/index.js'))).toBe(true)
     expect(await pathExists(resolve(CWD, 'built/esm/config.js'))).toBe(true)
-    expect(await pathExists(resolve(CWD, 'built/esm/objects/animal.js'))).toBe(true)
-    expect(await pathExists(resolve(CWD, 'built/esm/objects/horse.js'))).toBe(true)
-    expect(await pathExists(resolve(CWD, 'built/esm/objects/snake.js'))).toBe(true)
-    expect(await pathExists(resolve(CWD, 'built/esm/react/Counter.js'))).toBe(true)
-    expect(await pathExists(resolve(CWD, 'built/esm/react/Button.js'))).toBe(true)
+    expect(await pathExists(resolve(CWD, 'built/esm/objects/animal.js'))).toBe(
+      true,
+    )
+    expect(await pathExists(resolve(CWD, 'built/esm/objects/horse.js'))).toBe(
+      true,
+    )
+    expect(await pathExists(resolve(CWD, 'built/esm/objects/snake.js'))).toBe(
+      true,
+    )
+    expect(await pathExists(resolve(CWD, 'built/esm/react/Counter.js'))).toBe(
+      true,
+    )
+    expect(await pathExists(resolve(CWD, 'built/esm/react/Button.js'))).toBe(
+      true,
+    )
 
     expect(await pathExists(resolve(CWD, 'built/types/index.d.ts'))).toBe(true)
-    expect(await pathExists(resolve(CWD, 'built/types/objects/animal.d.ts'))).toBe(true)
-    expect(await pathExists(resolve(CWD, 'built/types/objects/snake.d.ts'))).toBe(true)
-    expect(await pathExists(resolve(CWD, 'built/types/objects/horse.d.ts'))).toBe(true)
-    expect(await pathExists(resolve(CWD, 'built/types/react/Counter.d.ts'))).toBe(true)
-    expect(await pathExists(resolve(CWD, 'built/types/react/Button.d.ts'))).toBe(true)
+    expect(
+      await pathExists(resolve(CWD, 'built/types/objects/animal.d.ts')),
+    ).toBe(true)
+    expect(
+      await pathExists(resolve(CWD, 'built/types/objects/snake.d.ts')),
+    ).toBe(true)
+    expect(
+      await pathExists(resolve(CWD, 'built/types/objects/horse.d.ts')),
+    ).toBe(true)
+    expect(
+      await pathExists(resolve(CWD, 'built/types/react/Counter.d.ts')),
+    ).toBe(true)
+    expect(
+      await pathExists(resolve(CWD, 'built/types/react/Button.d.ts')),
+    ).toBe(true)
   })
   it('does not create CJS files', async () => {
     expect(await pathExists(resolve(CWD, 'built/cjs/index.js'))).toBe(false)
-    expect(await pathExists(resolve(CWD, 'built/cjs/objects/animal.js'))).toBe(false)
-    expect(await pathExists(resolve(CWD, 'built/cjs/objects/snake.js'))).toBe(false)
-    expect(await pathExists(resolve(CWD, 'built/cjs/objects/horse.js'))).toBe(false)
-    expect(await pathExists(resolve(CWD, 'built/cjs/react/Counter.js'))).toBe(false)
-    expect(await pathExists(resolve(CWD, 'built/cjs/react/Button.js'))).toBe(false)
+    expect(await pathExists(resolve(CWD, 'built/cjs/objects/animal.js'))).toBe(
+      false,
+    )
+    expect(await pathExists(resolve(CWD, 'built/cjs/objects/snake.js'))).toBe(
+      false,
+    )
+    expect(await pathExists(resolve(CWD, 'built/cjs/objects/horse.js'))).toBe(
+      false,
+    )
+    expect(await pathExists(resolve(CWD, 'built/cjs/react/Counter.js'))).toBe(
+      false,
+    )
+    expect(await pathExists(resolve(CWD, 'built/cjs/react/Button.js'))).toBe(
+      false,
+    )
   })
   it('does not put files in default location', async () => {
     expect(await pathExists(resolve(CWD, 'lib/esm/index.js'))).toBe(false)
     expect(await pathExists(resolve(CWD, 'lib/types/index.d.ts'))).toBe(false)
     expect(await pathExists(resolve(CWD, 'lib/esm/config.js'))).toBe(false)
-    expect(await pathExists(resolve(CWD, 'lib/esm/objects/animal.js'))).toBe(false)
-    expect(await pathExists(resolve(CWD, 'lib/types/objects/snake.d.ts'))).toBe(false)
+    expect(await pathExists(resolve(CWD, 'lib/esm/objects/animal.js'))).toBe(
+      false,
+    )
+    expect(await pathExists(resolve(CWD, 'lib/types/objects/snake.d.ts'))).toBe(
+      false,
+    )
   })
 })

--- a/integration-tests/src/index.ts
+++ b/integration-tests/src/index.ts
@@ -8,7 +8,6 @@ import Snake from './objects/snake'
 import Horse from './objects/horse'
 import Counter from './react/Counter'
 
-
 const PACKAGE_JSON = readFileSync(resolve(__dirname, '../package.json'))
 
 export const run = (): void => {

--- a/integration-tests/src/react/Button.tsx
+++ b/integration-tests/src/react/Button.tsx
@@ -1,15 +1,11 @@
 import React, { FunctionComponent, ReactNode } from 'react'
 
-
 interface Props {
-  children: ReactNode;
-  onClick?: () => void;
+  children: ReactNode
+  onClick?: () => void
 }
 
-const Button: FunctionComponent<Props> = ({
-  onClick,
-  children,
-}) => (
+const Button: FunctionComponent<Props> = ({ onClick, children }) => (
   <button type="button" onClick={() => onClick && onClick()}>
     {children}
   </button>

--- a/integration-tests/src/react/Counter.tsx
+++ b/integration-tests/src/react/Counter.tsx
@@ -3,12 +3,10 @@ import React, { useState, FunctionComponent } from 'react'
 import Button from './Button'
 
 interface Props {
-  initialCount?: number;
+  initialCount?: number
 }
 
-const Counter: FunctionComponent<Props> = ({
-  initialCount = 0,
-}) => {
+const Counter: FunctionComponent<Props> = ({ initialCount = 0 }) => {
   // Declare a new state variable, which we'll call "count"
   const [count, setCount] = useState(initialCount)
   const onClick = (): void => setCount(count + 1)
@@ -16,9 +14,7 @@ const Counter: FunctionComponent<Props> = ({
   return (
     <div>
       <p className="text--medium">You clicked {count} times</p>
-      <Button onClick={onClick}>
-        Click me
-      </Button>
+      <Button onClick={onClick}>Click me</Button>
     </div>
   )
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9239,6 +9239,11 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
+    "prettier": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
+    },
     "pretty-format": {
       "version": "24.8.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
@@ -9314,6 +9319,29 @@
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+    },
+    "react": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
+      "integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2"
+      }
+    },
+    "react-dom": {
+      "version": "16.12.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.12.0.tgz",
+      "integrity": "sha512-LMxFfAGrcS3kETtQaCkTKjMiifahaMySFDn71fZUNpPHZQEzmk/GiAeIT8JSOrHB23fnuCOMruL2a8NYlw+8Gw==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.6.2",
+        "scheduler": "^0.18.0"
+      }
     },
     "react-is": {
       "version": "16.8.6",
@@ -9666,6 +9694,16 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
+    "scheduler": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.18.0.tgz",
+      "integrity": "sha512-agTSHR1Nbfi6ulI0kYNK0203joW2Y5W4po4l+v03tOoiJKpTBbxpNhWDvqc/4IcOw+KLmSiQLTasZ4cab2/UWQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
     },
     "semver": {
       "version": "5.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3171,6 +3171,11 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/color-name": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -3280,11 +3285,11 @@
       "integrity": "sha512-gCubfBUZ6KxzoibJ+SCUc/57Ms1jz5NjHe4+dI2krNmU5zCPAphyLJYyTOg06ueIyfj+SaCUqmzun7ImlxDcKg=="
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.11.0.tgz",
-      "integrity": "sha512-G2HHA1vpMN0EEbUuWubiCCfd0R3a30BB+UdvnFkxwZIxYEGOrWEXDv8tBFO9f44CWc47Xv9lLM3VSn4ORLI2bA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.12.0.tgz",
+      "integrity": "sha512-1t4r9rpLuEwl3hgt90jY18wJHSyb0E3orVL3DaqwmpiSDHmHiSspVsvsFF78BJ/3NNG3qmeso836jpuBWYziAA==",
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.11.0",
+        "@typescript-eslint/experimental-utils": "2.12.0",
         "eslint-utils": "^1.4.3",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
@@ -3292,30 +3297,30 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.11.0.tgz",
-      "integrity": "sha512-YxcA/y0ZJaCc/fB/MClhcDxHI0nOBB7v2/WxBju2cOTanX7jO9ttQq6Fy4yW9UaY5bPd9xL3cun3lDVqk67sPQ==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.12.0.tgz",
+      "integrity": "sha512-jv4gYpw5N5BrWF3ntROvCuLe1IjRenLy5+U57J24NbPGwZFAjhnM45qpq0nDH1y/AZMb3Br25YiNVwyPbz6RkA==",
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.11.0",
+        "@typescript-eslint/typescript-estree": "2.12.0",
         "eslint-scope": "^5.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.11.0.tgz",
-      "integrity": "sha512-DyGXeqhb3moMioEFZIHIp7oXBBh7dEfPTzGrlyP0Mi9ScCra4SWEGs3kPd18mG7Sy9Wy8z88zmrw5tSGL6r/6A==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.12.0.tgz",
+      "integrity": "sha512-lPdkwpdzxEfjI8TyTzZqPatkrswLSVu4bqUgnB03fHSOwpC7KSerPgJRgIAf11UGNf7HKjJV6oaPZI4AghLU6g==",
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.11.0",
-        "@typescript-eslint/typescript-estree": "2.11.0",
+        "@typescript-eslint/experimental-utils": "2.12.0",
+        "@typescript-eslint/typescript-estree": "2.12.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.11.0.tgz",
-      "integrity": "sha512-HGY4+d4MagO6cKMcKfIKaTMxcAv7dEVnji2Zi+vi5VV8uWAM631KjAB5GxFcexMYrwKT0EekRiiGK1/Sd7VFGA==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.12.0.tgz",
+      "integrity": "sha512-rGehVfjHEn8Frh9UW02ZZIfJs6SIIxIu/K1bbci8rFfDE/1lQ8krIJy5OXOV3DVnNdDPtoiPOdEANkLMrwXbiQ==",
       "requires": {
         "debug": "^4.1.1",
         "eslint-visitor-keys": "^1.1.0",
@@ -4552,6 +4557,14 @@
         "object.entries": "^1.1.0"
       }
     },
+    "eslint-config-prettier": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.7.0.tgz",
+      "integrity": "sha512-FamQVKM3jjUVwhG4hEMnbtsq7xOIDm+SY5iBPfR8gKsJoAB2IQnNF+bk1+8Fy44Nq7PPJaLvkRxILYdJWoguKQ==",
+      "requires": {
+        "get-stdin": "^6.0.0"
+      }
+    },
     "eslint-import-resolver-node": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
@@ -4769,6 +4782,14 @@
         "jsx-ast-utils": "^2.2.1"
       }
     },
+    "eslint-plugin-prettier": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
+      "integrity": "sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==",
+      "requires": {
+        "prettier-linter-helpers": "^1.0.0"
+      }
+    },
     "eslint-plugin-react": {
       "version": "7.17.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.17.0.tgz",
@@ -4853,9 +4874,9 @@
       }
     },
     "eslint-plugin-react-hooks": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-1.7.0.tgz",
-      "integrity": "sha512-iXTCFcOmlWvw4+TOE8CLWj6yX1GwzT0Y6cUfHHZqWnSk144VmVIRcVGtUAzrLES7C798lmvnt02C7rxaOX1HNA=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.3.0.tgz",
+      "integrity": "sha512-gLKCa52G4ee7uXzdLiorca7JIQZPPXRAQDXV83J4bUEeUuc5pIEyZYAZ45Xnxe5IuupxEqHS+hUhSLIimK1EMw=="
     },
     "eslint-plugin-testing-library": {
       "version": "1.3.4",
@@ -5218,6 +5239,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
       "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+    },
+    "fast-diff": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
+      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
@@ -5840,6 +5866,11 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
+    "get-stdin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
+      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g=="
     },
     "get-stream": {
       "version": "4.1.0",
@@ -9244,6 +9275,14 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
       "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
     },
+    "prettier-linter-helpers": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
+      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "requires": {
+        "fast-diff": "^1.1.2"
+      }
+    },
     "pretty-format": {
       "version": "24.8.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.8.0.tgz",
@@ -10620,50 +10659,112 @@
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
     },
     "yargs": {
-      "version": "14.2.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.2.tgz",
-      "integrity": "sha512-/4ld+4VV5RnrynMhPZJ/ZpOCGSCeghMykZ3BhdFBDa9Wy/RH6uEGNWDJog+aUlq+9OM1CFTgtYRW5Is1Po9NOA==",
+      "version": "15.0.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.0.2.tgz",
+      "integrity": "sha512-GH/X/hYt+x5hOat4LMnCqMd8r5Cv78heOMIJn1hr7QPPBqfeC6p89Y78+WB9yGDvfpCvgasfmWLzNzEioOUD9Q==",
       "requires": {
-        "cliui": "^5.0.0",
+        "cliui": "^6.0.0",
         "decamelize": "^1.2.0",
-        "find-up": "^3.0.0",
+        "find-up": "^4.1.0",
         "get-caller-file": "^2.0.1",
         "require-directory": "^2.1.1",
         "require-main-filename": "^2.0.0",
         "set-blocking": "^2.0.0",
-        "string-width": "^3.0.0",
+        "string-width": "^4.2.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^15.0.0"
+        "yargs-parser": "^16.1.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
         },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+        "ansi-styles": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.0.tgz",
+          "integrity": "sha512-7kFQgnEaMdRtwf6uSfUnVr9gSGC7faurn+J/Mv90/W+iTtN0405/nLdopfMWwchyxhbGYl6TC4Sccn9TUkGAgg==",
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "@types/color-name": "^1.1.1",
+            "color-convert": "^2.0.1"
           }
         },
-        "strip-ansi": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+        "cliui": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
           "requires": {
-            "ansi-regex": "^4.1.0"
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^6.2.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+          "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+          "requires": {
+            "p-locate": "^4.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+          "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+          "requires": {
+            "p-limit": "^2.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "6.2.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
           }
         },
         "yargs-parser": {
-          "version": "15.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.0.tgz",
-          "integrity": "sha512-xLTUnCMc4JhxrPEPUYD5IBR1mWCK/aT6+RJ/K29JY2y1vD+FhtgKK0AXRWvI262q3QSffAQuTouFIKUuHX89wQ==",
+          "version": "16.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-16.1.0.tgz",
+          "integrity": "sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==",
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "prebuild": "npm run bootstrap",
     "build": "./bin/benmvp build",
     "preintegrate": "npm run build",
-    "integrate": "./bin/benmvp integrate",
-    "format": "prettier --write '**/*.*'"
+    "integrate": "./bin/benmvp integrate"
   },
   "engines": {
     "node": ">= 8"
@@ -50,17 +49,19 @@
     "@testing-library/react": "^9.3.3",
     "@types/jest": "^24.0.23",
     "@types/node": "^12.12.17",
-    "@typescript-eslint/eslint-plugin": "^2.11.0",
-    "@typescript-eslint/parser": "^2.11.0",
+    "@typescript-eslint/eslint-plugin": "^2.12.0",
+    "@typescript-eslint/parser": "^2.12.0",
     "babel-jest": "^24.9.0",
     "eslint": "^6.7.2",
     "eslint-config-airbnb": "^18.0.1",
+    "eslint-config-prettier": "^6.7.0",
     "eslint-plugin-import": "^2.19.1",
     "eslint-plugin-jest": "^22.21.0",
     "eslint-plugin-jest-dom": "^1.3.0",
     "eslint-plugin-jsx-a11y": "^6.2.3",
+    "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.17.0",
-    "eslint-plugin-react-hooks": "^1.7.0",
+    "eslint-plugin-react-hooks": "^2.3.0",
     "eslint-plugin-testing-library": "^1.3.4",
     "jest": "^24.9.0",
     "jest-runner-eslint": "^0.7.5",
@@ -70,7 +71,7 @@
     "prettier": "1.19.1",
     "rimraf": "^3.0.0",
     "typescript": "^3.7.3",
-    "yargs": "^14.2.2"
+    "yargs": "^15.0.2"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.149",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "prebuild": "npm run bootstrap",
     "build": "./bin/benmvp build",
     "preintegrate": "npm run build",
-    "integrate": "./bin/benmvp integrate"
+    "integrate": "./bin/benmvp integrate",
+    "format": "prettier --write"
   },
   "engines": {
     "node": ">= 8"
@@ -66,12 +67,15 @@
     "jest-runner-tsc": "^1.6.0",
     "jest-watch-typeahead": "^0.3.0",
     "lodash": "^4.17.15",
+    "prettier": "1.19.1",
     "rimraf": "^3.0.0",
     "typescript": "^3.7.3",
     "yargs": "^14.2.2"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.149",
-    "@types/yargs": "^13.0.3"
+    "@types/yargs": "^13.0.3",
+    "react": "^16.12.0",
+    "react-dom": "^16.12.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build": "./bin/benmvp build",
     "preintegrate": "npm run build",
     "integrate": "./bin/benmvp integrate",
-    "format": "prettier --write"
+    "format": "prettier --write '**/*.*'"
   },
   "engines": {
     "node": ">= 8"

--- a/src/cli/__tests__/index.spec.ts
+++ b/src/cli/__tests__/index.spec.ts
@@ -272,7 +272,17 @@ describe('run', () => {
       })
 
       it('parses multiple arguments (aliases)', () => {
-        run(['create', 'test-lib', '-m', 'type', '-o', './built', '-f', 'esm', 'type'])
+        run([
+          'create',
+          'test-lib',
+          '-m',
+          'type',
+          '-o',
+          './built',
+          '-f',
+          'esm',
+          'type',
+        ])
 
         expect(create).toHaveBeenCalledWith({
           name: 'test-lib',
@@ -466,7 +476,15 @@ describe('run', () => {
 
     describe('combination', () => {
       it('parses multiple arguments', () => {
-        run(['build', '--out', './output', '--watch', '--formats', 'esm', 'cjs'])
+        run([
+          'build',
+          '--out',
+          './output',
+          '--watch',
+          '--formats',
+          'esm',
+          'cjs',
+        ])
 
         expect(build).toHaveBeenCalledWith({
           formats: ['esm', 'cjs'],
@@ -590,7 +608,15 @@ describe('run', () => {
       })
 
       it('parses all args', () => {
-        run(['test', '--watch', '--modes', 'spec', 'type', '--pattern', 'utils/'])
+        run([
+          'test',
+          '--watch',
+          '--modes',
+          'spec',
+          'type',
+          '--pattern',
+          'utils/',
+        ])
 
         expect(testCommand).toHaveBeenCalledWith({
           modes: ['spec', 'type'],
@@ -663,7 +689,6 @@ describe('run', () => {
           pattern: START_ARGS.pattern.default,
         })
       })
-
 
       it('parses pattern', () => {
         const pattern = 'api/'
@@ -741,7 +766,6 @@ describe('run', () => {
           pattern: INTEGRATE_ARGS.pattern.default,
         })
       })
-
 
       it('parses pattern', () => {
         const pattern = 'api/'

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -3,13 +3,13 @@ import yargs from 'yargs'
 import { ModuleFormat, TestMode, Command } from '../commands/types'
 
 interface CommandOptions {
-  [key: string]: yargs.Options;
+  [key: string]: yargs.Options
 }
 
 interface YargsArgv {
-  [x: string]: unknown;
-  _: string[];
-  $0: string;
+  [x: string]: unknown
+  _: string[]
+  $0: string
 }
 
 const TEST_MODES = {
@@ -22,7 +22,8 @@ const TEST_MODES = {
 }
 const TEST_PATTERN = {
   pattern: {
-    describe: 'Regexp pattern string that is matched against all tests paths before executing the test',
+    describe:
+      'Regexp pattern string that is matched against all tests paths before executing the test',
     alias: 'p',
     string: true,
     default: '',
@@ -90,34 +91,39 @@ export const INTEGRATE_COMMAND = 'integrate' as Command
 
 export const DEFAULT_COMMAND = CREATE_COMMAND
 
-export const parseArgs = (args: string[]): YargsArgv => yargs(args)
-  .version()
-  .command<CommandOptions>(
-    TEST_COMMAND,
-    'Runs linting, typing & Jest tests for the library',
-    TEST_ARGS,
-  )
-  .command<CommandOptions>(
-    START_COMMAND,
-    'Runs the lib\'s tests in watch mode',
-    START_ARGS,
-  )
-  .command<CommandOptions>(
-    BUILD_COMMAND,
-    'Builds the library into desired module formats',
-    BUILD_ARGS,
-  )
-  .command<CommandOptions>(
-    INTEGRATE_COMMAND,
-    'Runs integration tests for the library',
-    INTEGRATE_ARGS,
-  )
-  .command(
-    [`${CREATE_COMMAND} [name]`, '$0'],
-    'Creates a new library with test/build infra using @benmvp/cli',
-    (commandYargs: yargs.Argv) => commandYargs.options(CREATE_ARGS).positional('name', CREATE_POS_ARGS.name),
-  )
-  .completion()
-  .epilog('For more details, visit https://github.com/benmvp/benmvp-cli/blob/master/API.md')
-  .help()
-  .argv
+export const parseArgs = (args: string[]): YargsArgv =>
+  yargs(args)
+    .version()
+    .command<CommandOptions>(
+      TEST_COMMAND,
+      'Runs linting, typing & Jest tests for the library',
+      TEST_ARGS,
+    )
+    .command<CommandOptions>(
+      START_COMMAND,
+      "Runs the lib's tests in watch mode",
+      START_ARGS,
+    )
+    .command<CommandOptions>(
+      BUILD_COMMAND,
+      'Builds the library into desired module formats',
+      BUILD_ARGS,
+    )
+    .command<CommandOptions>(
+      INTEGRATE_COMMAND,
+      'Runs integration tests for the library',
+      INTEGRATE_ARGS,
+    )
+    .command(
+      [`${CREATE_COMMAND} [name]`, '$0'],
+      'Creates a new library with test/build infra using @benmvp/cli',
+      (commandYargs: yargs.Argv) =>
+        commandYargs
+          .options(CREATE_ARGS)
+          .positional('name', CREATE_POS_ARGS.name),
+    )
+    .completion()
+    .epilog(
+      'For more details, visit https://github.com/benmvp/benmvp-cli/blob/master/API.md',
+    )
+    .help().argv

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -1,11 +1,5 @@
 import pick from 'lodash/pick'
-import {
-  create,
-  test as testCommand,
-  start,
-  build,
-  integrate,
-} from '..'
+import { create, test as testCommand, start, build, integrate } from '..'
 import {
   CREATE_ARGS,
   CREATE_POS_ARGS,
@@ -32,7 +26,10 @@ export const run = (args: string[] = []): Promise<Result> => {
   switch (command) {
     case 'create':
       return create(
-        pick(parsedArgs, [...Object.keys(CREATE_ARGS), ...Object.keys(CREATE_POS_ARGS)]),
+        pick(parsedArgs, [
+          ...Object.keys(CREATE_ARGS),
+          ...Object.keys(CREATE_POS_ARGS),
+        ]),
       )
     case 'build':
       return build(pick(parsedArgs, Object.keys(BUILD_ARGS)))

--- a/src/commands/build/__tests__/utils.spec.ts
+++ b/src/commands/build/__tests__/utils.spec.ts
@@ -42,10 +42,16 @@ describe('getBabelArgs', () => {
       })
 
       expect(cjsArgs.babelOptions.presets[0]).toMatch('babel-config-cjs.js')
-      expect(cjsArgs.cliOptions).toHaveProperty('outDir', resolve(CWD, 'lib/cjs'))
+      expect(cjsArgs.cliOptions).toHaveProperty(
+        'outDir',
+        resolve(CWD, 'lib/cjs'),
+      )
 
       expect(esmArgs.babelOptions.presets[0]).toMatch('babel-config-esm.js')
-      expect(esmArgs.cliOptions).toHaveProperty('outDir', resolve(CWD, 'lib/esm'))
+      expect(esmArgs.cliOptions).toHaveProperty(
+        'outDir',
+        resolve(CWD, 'lib/esm'),
+      )
     })
 
     it('still only generates CJS + ESM when more formats are specified', () => {
@@ -58,10 +64,16 @@ describe('getBabelArgs', () => {
       expect(otherArgs).toHaveLength(0)
 
       expect(cjsArgs.babelOptions.presets[0]).toMatch('babel-config-cjs.js')
-      expect(cjsArgs.cliOptions).toHaveProperty('outDir', resolve(CWD, 'lib/cjs'))
+      expect(cjsArgs.cliOptions).toHaveProperty(
+        'outDir',
+        resolve(CWD, 'lib/cjs'),
+      )
 
       expect(esmArgs.babelOptions.presets[0]).toMatch('babel-config-esm.js')
-      expect(esmArgs.cliOptions).toHaveProperty('outDir', resolve(CWD, 'lib/esm'))
+      expect(esmArgs.cliOptions).toHaveProperty(
+        'outDir',
+        resolve(CWD, 'lib/esm'),
+      )
     })
 
     it('sets correct outDir when `out` is relative', () => {
@@ -145,9 +157,13 @@ describe('getTypescriptArgs', () => {
         watch: BUILD_ARGS.watch.default,
       })
 
-      Object.entries(BASE_TSCONFIG.compilerOptions).forEach(([optionName, optionValue]) => {
-        expect(typescriptArgs).toEqual(expect.arrayContaining([`--${optionName}`, `${optionValue}`]))
-      })
+      Object.entries(BASE_TSCONFIG.compilerOptions).forEach(
+        ([optionName, optionValue]) => {
+          expect(typescriptArgs).toEqual(
+            expect.arrayContaining([`--${optionName}`, `${optionValue}`]),
+          )
+        },
+      )
     })
 
     it('specifies generic declaration information', () => {
@@ -159,7 +175,9 @@ describe('getTypescriptArgs', () => {
 
       expect(typescriptArgs).toContain('--declaration')
       expect(typescriptArgs).toContain('--emitDeclarationOnly')
-      expect(typescriptArgs).toEqual(expect.arrayContaining(['--noEmit', 'false']))
+      expect(typescriptArgs).toEqual(
+        expect.arrayContaining(['--noEmit', 'false']),
+      )
     })
 
     it('specifies the declaration destination when `out` is relative', () => {
@@ -170,10 +188,9 @@ describe('getTypescriptArgs', () => {
         watch: BUILD_ARGS.watch.default,
       })
 
-      expect(typescriptArgs).toEqual(expect.arrayContaining([
-        '--declarationDir',
-        resolve(out, 'types'),
-      ]))
+      expect(typescriptArgs).toEqual(
+        expect.arrayContaining(['--declarationDir', resolve(out, 'types')]),
+      )
     })
 
     it('specifies the declaration destination when `out` is absolute', () => {
@@ -183,10 +200,9 @@ describe('getTypescriptArgs', () => {
         watch: BUILD_ARGS.watch.default,
       })
 
-      expect(typescriptArgs).toEqual(expect.arrayContaining([
-        '--declarationDir',
-        '/out/dir/types',
-      ]))
+      expect(typescriptArgs).toEqual(
+        expect.arrayContaining(['--declarationDir', '/out/dir/types']),
+      )
     })
 
     describe('watch option', () => {

--- a/src/commands/build/babel-config-cjs.js
+++ b/src/commands/build/babel-config-cjs.js
@@ -1,4 +1,4 @@
-const {getBabelConfig} = require('./babel-config-utils')
+const { getBabelConfig } = require('./babel-config-utils')
 
 module.exports = (api) => {
   api.cache.forever()

--- a/src/commands/build/babel-config-esm.js
+++ b/src/commands/build/babel-config-esm.js
@@ -1,4 +1,4 @@
-const {getBabelConfig} = require('./babel-config-utils')
+const { getBabelConfig } = require('./babel-config-utils')
 
 module.exports = (api) => {
   api.cache.forever()

--- a/src/commands/build/babel-config-utils.js
+++ b/src/commands/build/babel-config-utils.js
@@ -15,18 +15,21 @@ const getBabelConfig = (moduleType) => ({
     '@babel/preset-typescript',
   ],
   plugins: [
-    ['@babel/plugin-proposal-class-properties', {loose: true}],
+    ['@babel/plugin-proposal-class-properties', { loose: true }],
     '@babel/plugin-proposal-object-rest-spread',
-    ['@babel/plugin-transform-runtime', {
-      corejs: false,
-      helpers: false,
-      regenerator: true,
+    [
+      '@babel/plugin-transform-runtime',
+      {
+        corejs: false,
+        helpers: false,
+        regenerator: true,
 
-      // NOTE: May need to point this to a specific one, see
-      // https://github.com/facebook/create-react-app/blob/695ca7576a6d27912bcf9d992b00ef7316232555/packages/babel-preset-react-app/create.js#L181
-      absoluteRuntime: false,
-    }]
+        // NOTE: May need to point this to a specific one, see
+        // https://github.com/facebook/create-react-app/blob/695ca7576a6d27912bcf9d992b00ef7316232555/packages/babel-preset-react-app/create.js#L181
+        absoluteRuntime: false,
+      },
+    ],
   ],
 })
 
-module.exports = {getBabelConfig}
+module.exports = { getBabelConfig }

--- a/src/commands/build/index.ts
+++ b/src/commands/build/index.ts
@@ -35,9 +35,12 @@ export default async ({
     // eslint-disable-next-line no-console
     console.log(
       '\nBuilding...',
-      '\n  formats:', formats.toString(),
-      '\n  output dir:', out,
-      '\n  watching?', watch ? 'yes' : 'no',
+      '\n  formats:',
+      formats.toString(),
+      '\n  output dir:',
+      out,
+      '\n  watching?',
+      watch ? 'yes' : 'no',
       '\n',
     )
 

--- a/src/commands/build/utils.ts
+++ b/src/commands/build/utils.ts
@@ -4,63 +4,60 @@ import { ModuleFormat } from '../types'
 import BASE_TSCONFIG from '../test/tsconfig.json'
 
 interface BabelOptions {
-  presets: string[];
-  plugins?: string[];
-  rootMode?: 'root' | 'upward' | 'upward-optional';
-  configFile?: string;
-  envName?: string;
-  sourceType?: 'script' | 'module';
-  ignore?: string[];
-  only?: string[];
-  retainLines?: boolean;
-  compact?: true | false | 'auto';
-  minified?: boolean;
-  auxiliaryCommentBefore?: string;
-  auxiliaryCommentAfter?: string;
-  sourceMaps?: boolean;
-  sourceFileName?: string;
-  sourceRoot?: string;
-  moduleRoot?: string;
-  moduleIds?: string[];
-  moduleId?: string;
-  babelrc?: boolean;
-  highlightCode?: boolean;
-  comments?: boolean;
+  presets: string[]
+  plugins?: string[]
+  rootMode?: 'root' | 'upward' | 'upward-optional'
+  configFile?: string
+  envName?: string
+  sourceType?: 'script' | 'module'
+  ignore?: string[]
+  only?: string[]
+  retainLines?: boolean
+  compact?: true | false | 'auto'
+  minified?: boolean
+  auxiliaryCommentBefore?: string
+  auxiliaryCommentAfter?: string
+  sourceMaps?: boolean
+  sourceFileName?: string
+  sourceRoot?: string
+  moduleRoot?: string
+  moduleIds?: string[]
+  moduleId?: string
+  babelrc?: boolean
+  highlightCode?: boolean
+  comments?: boolean
 }
 interface CLIOptions {
-  filename?: string;
-  filenames: string[];
-  extensions?: string;
-  keepFileExtension?: boolean;
-  watch?: boolean;
-  skipInitialBuild?: boolean;
-  outFile?: string;
-  outDir?: string;
-  relative?: boolean;
-  copyFiles?: boolean;
-  includeDotfiles?: boolean;
-  verbose?: boolean;
-  deleteDirOnStart?: boolean;
-  sourceMapTarget?: string;
+  filename?: string
+  filenames: string[]
+  extensions?: string
+  keepFileExtension?: boolean
+  watch?: boolean
+  skipInitialBuild?: boolean
+  outFile?: string
+  outDir?: string
+  relative?: boolean
+  copyFiles?: boolean
+  includeDotfiles?: boolean
+  verbose?: boolean
+  deleteDirOnStart?: boolean
+  sourceMapTarget?: string
 }
 
 interface BabelCLIOptions {
-  babelOptions: BabelOptions;
-  cliOptions: CLIOptions;
+  babelOptions: BabelOptions
+  cliOptions: CLIOptions
 }
 
 interface BuildArgs {
-  formats: Set<ModuleFormat>;
-  out: string;
-  watch: boolean;
+  formats: Set<ModuleFormat>
+  out: string
+  watch: boolean
 }
 
 const VALID_BABEL_FORMATS = new Set(['cjs', 'esm'] as ModuleFormat[])
 
-const BUILT_FILES_TO_REMOVE = [
-  '**/__tests__/',
-  '**/*.spec.*',
-]
+const BUILT_FILES_TO_REMOVE = ['**/__tests__/', '**/*.spec.*']
 
 /**
  * Gets an array of options/arguments to pass babel, one for each valid format
@@ -72,24 +69,28 @@ const BUILT_FILES_TO_REMOVE = [
  *  generate the built module formats whenever source files change
  * @returns {BabelCLIOptions[]}
  */
-export const getBabelArgs = ({ formats, out: outputPath, watch }: BuildArgs): BabelCLIOptions[] => {
-  const validatedFormats = [...formats].filter((format) => VALID_BABEL_FORMATS.has(format))
-
-  const argsList = validatedFormats.map(
-    (format) => ({
-      babelOptions: {
-        presets: [resolve(__dirname, `babel-config-${format}.js`)],
-        babelrc: false,
-      },
-      cliOptions: {
-        filenames: [resolve(process.cwd(), 'src')],
-        outDir: resolve(outputPath, format),
-        extensions: '.ts,.tsx,.js,.jsx',
-        watch,
-        copyFiles: true,
-      },
-    }),
+export const getBabelArgs = ({
+  formats,
+  out: outputPath,
+  watch,
+}: BuildArgs): BabelCLIOptions[] => {
+  const validatedFormats = [...formats].filter((format) =>
+    VALID_BABEL_FORMATS.has(format),
   )
+
+  const argsList = validatedFormats.map((format) => ({
+    babelOptions: {
+      presets: [resolve(__dirname, `babel-config-${format}.js`)],
+      babelrc: false,
+    },
+    cliOptions: {
+      filenames: [resolve(process.cwd(), 'src')],
+      outDir: resolve(outputPath, format),
+      extensions: '.ts,.tsx,.js,.jsx',
+      watch,
+      copyFiles: true,
+    },
+  }))
 
   return argsList
 }
@@ -104,23 +105,32 @@ export const getBabelArgs = ({ formats, out: outputPath, watch }: BuildArgs): Ba
  *  generate the type definitions whenever source files change
  * @returns {string[] | null}
  */
-export const getTypescriptArgs = ({ formats, out, watch }: BuildArgs): string[] | null => {
+export const getTypescriptArgs = ({
+  formats,
+  out,
+  watch,
+}: BuildArgs): string[] | null => {
   if (!formats.has('type')) {
     return null
   }
 
   const { compilerOptions } = BASE_TSCONFIG
   const compilerOptionsAsArgs = flatten(
-    Object.entries(compilerOptions).map(([optionName, optionValue]) => ([`--${optionName}`, `${optionValue}`])),
+    Object.entries(compilerOptions).map(([optionName, optionValue]) => [
+      `--${optionName}`,
+      `${optionValue}`,
+    ]),
   )
 
   const args = [
     ...compilerOptionsAsArgs,
     '--pretty',
     '--declaration',
-    '--declarationDir', resolve(out, 'types'),
+    '--declarationDir',
+    resolve(out, 'types'),
     '--emitDeclarationOnly',
-    '--noEmit', 'false',
+    '--noEmit',
+    'false',
     watch ? '--watch' : '',
     resolve(process.cwd(), 'src/index.ts'),
   ]
@@ -134,6 +144,5 @@ export const getTypescriptArgs = ({ formats, out, watch }: BuildArgs): string[] 
  *  for the type definitions
  * @returns {string[]}
  */
-export const getCopiedFilesToDelete = (outputPath: string): string[] => (
+export const getCopiedFilesToDelete = (outputPath: string): string[] =>
   BUILT_FILES_TO_REMOVE.map((glob) => resolve(`${outputPath}/${glob}`))
-)

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -19,7 +19,10 @@ export default async ({
 } = {}): Promise<Result> => {
   // eslint-disable-next-line no-console
   console.log('run create', {
-    formats, out, modes, libraryName,
+    formats,
+    out,
+    modes,
+    libraryName,
   })
 
   return {

--- a/src/commands/integrate/__tests__/utils.spec.ts
+++ b/src/commands/integrate/__tests__/utils.spec.ts
@@ -1,7 +1,6 @@
 import { getTestArgs, IntegrateParams } from '../utils'
 import { TestMode } from '../../types'
 
-
 describe('getTestArgs', () => {
   it('throws an error if no args are specified', () => {
     const tryGet = (): void => {
@@ -47,7 +46,9 @@ describe('getTestArgs', () => {
     it('returns multiple args when multiple valid modes are specified', () => {
       const actual = getTestArgs({ modes: ['lint', 'spec'], pattern: '' })
 
-      expect(actual).toEqual(expect.arrayContaining(['--modes', 'lint', 'spec']))
+      expect(actual).toEqual(
+        expect.arrayContaining(['--modes', 'lint', 'spec']),
+      )
     })
   })
 

--- a/src/commands/integrate/index.ts
+++ b/src/commands/integrate/index.ts
@@ -4,10 +4,9 @@ import { INTEGRATE_ARGS } from '../../cli/args'
 import { Result } from '../types'
 import { getTestArgs } from './utils'
 
-
 const SCRIPT_PATH = pathResolve(__dirname, 'run.sh')
 
-const spawnAsync = (command: string, args: string[]): Promise<void> => (
+const spawnAsync = (command: string, args: string[]): Promise<void> =>
   new Promise((resolve, reject) => {
     const childProcess = spawn(command, args)
 
@@ -21,14 +20,14 @@ const spawnAsync = (command: string, args: string[]): Promise<void> => (
     })
     childProcess.on('close', (code) => {
       if (code !== 0) {
-        reject(new Error(`"${command} ${args.join(' ')}" exited with code ${code}`))
+        reject(
+          new Error(`"${command} ${args.join(' ')}" exited with code ${code}`),
+        )
       } else {
         resolve()
       }
     })
   })
-)
-
 
 /**
  * Runs a one-time pass of the specified integration tests

--- a/src/commands/integrate/run.sh
+++ b/src/commands/integrate/run.sh
@@ -28,13 +28,15 @@ if [ ! -f $TARBALL_FILE_PATH ]; then
   exit 1
 fi
 
+# copy the prettier configs over to $TEMP_INTEGRATION_PATH
+# copy this first before copying the "project" just in case
+# they decide to put prettier configs within it
+echo -e "cp .prettier* $TEMP_INTEGRATION_PATH\n"
+cp .prettier* $TEMP_INTEGRATION_PATH
+
 # copy the integration tests "project" over to $TEMP_INTEGRATION_PATH
 echo -e "cp -r ./integration-tests/* $TEMP_INTEGRATION_PATH\n"
 cp -r ./integration-tests/. $TEMP_INTEGRATION_PATH
-
-# copy the prettier configs over to $TEMP_INTEGRATION_PATH
-echo -e "cp .prettier* $TEMP_INTEGRATION_PATH\n"
-cp .prettier* $TEMP_INTEGRATION_PATH
 
 echo -e "pushd $TEMP_INTEGRATION_PATH\n"
 pushd $TEMP_INTEGRATION_PATH

--- a/src/commands/integrate/run.sh
+++ b/src/commands/integrate/run.sh
@@ -30,7 +30,11 @@ fi
 
 # copy the integration tests "project" over to $TEMP_INTEGRATION_PATH
 echo -e "cp -r ./integration-tests/* $TEMP_INTEGRATION_PATH\n"
-cp -r ./integration-tests/* $TEMP_INTEGRATION_PATH
+cp -r ./integration-tests/. $TEMP_INTEGRATION_PATH
+
+# copy the prettier configs over to $TEMP_INTEGRATION_PATH
+echo -e "cp .prettier* $TEMP_INTEGRATION_PATH\n"
+cp .prettier* $TEMP_INTEGRATION_PATH
 
 echo -e "pushd $TEMP_INTEGRATION_PATH\n"
 pushd $TEMP_INTEGRATION_PATH

--- a/src/commands/integrate/utils.ts
+++ b/src/commands/integrate/utils.ts
@@ -1,10 +1,9 @@
 import { TestMode } from '../types'
 import { VALID_TEST_MODES } from '../test/utils'
 
-
 export interface IntegrateParams {
-  modes: TestMode[];
-  pattern: string;
+  modes: TestMode[]
+  pattern: string
 }
 
 const VALID_TEST_MODE_NAMES = new Set(Object.keys(VALID_TEST_MODES))
@@ -18,7 +17,9 @@ const VALID_TEST_MODE_NAMES = new Set(Object.keys(VALID_TEST_MODES))
  * @returns {string[]}
  */
 export const getTestArgs = ({ modes, pattern }: IntegrateParams): string[] => {
-  const validSelectedModes = modes.filter((mode) => VALID_TEST_MODE_NAMES.has(mode))
+  const validSelectedModes = modes.filter((mode) =>
+    VALID_TEST_MODE_NAMES.has(mode),
+  )
 
   if (!validSelectedModes.length || validSelectedModes.length < modes.length) {
     throw new Error(`Invalid test modes specified: ${modes}`)

--- a/src/commands/start/__tests__/index.spec.ts
+++ b/src/commands/start/__tests__/index.spec.ts
@@ -52,12 +52,14 @@ describe('success cases', () => {
       const result = await start({})
 
       expect(runJest).toHaveBeenCalledWith(expect.arrayContaining(['--watch']))
-      expect(runJest).toHaveBeenCalledWith(expect.arrayContaining([
-        '--projects',
-        expect.stringContaining('project-type.js'),
-        expect.stringContaining('project-lint.js'),
-        expect.stringContaining('project-spec.js'),
-      ]))
+      expect(runJest).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          '--projects',
+          expect.stringContaining('project-type.js'),
+          expect.stringContaining('project-lint.js'),
+          expect.stringContaining('project-spec.js'),
+        ]),
+      )
 
       expect(result).toEqual({ code: 0 })
     })
@@ -66,10 +68,12 @@ describe('success cases', () => {
       const result = await start({ modes: ['spec'] })
 
       expect(runJest).toHaveBeenCalledWith(expect.arrayContaining(['--watch']))
-      expect(runJest).toHaveBeenCalledWith(expect.arrayContaining([
-        '--projects',
-        expect.stringContaining('project-spec.js'),
-      ]))
+      expect(runJest).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          '--projects',
+          expect.stringContaining('project-spec.js'),
+        ]),
+      )
 
       expect(result).toEqual({ code: 0 })
     })
@@ -79,9 +83,9 @@ describe('success cases', () => {
     it('calls jest with args and returns success when no pattern is passed', async () => {
       const result = await start()
 
-      expect(runJest).toHaveBeenCalledWith(expect.not.arrayContaining([
-        '--pattern',
-      ]))
+      expect(runJest).toHaveBeenCalledWith(
+        expect.not.arrayContaining(['--pattern']),
+      )
 
       expect(result).toEqual({ code: 0 })
     })
@@ -90,10 +94,9 @@ describe('success cases', () => {
       const pattern = 'utils/'
       const result = await start({ pattern })
 
-      expect(runJest).toHaveBeenCalledWith(expect.arrayContaining([
-        '--testPathPattern',
-        pattern,
-      ]))
+      expect(runJest).toHaveBeenCalledWith(
+        expect.arrayContaining(['--testPathPattern', pattern]),
+      )
 
       expect(result).toEqual({ code: 0 })
     })

--- a/src/commands/start/index.ts
+++ b/src/commands/start/index.ts
@@ -13,8 +13,9 @@ import testCommand from '../test'
 export default ({
   modes = START_ARGS.modes.default,
   pattern = START_ARGS.pattern.default,
-} = {}): Promise<Result> => testCommand({
-  modes,
-  pattern,
-  watch: true,
-})
+} = {}): Promise<Result> =>
+  testCommand({
+    modes,
+    pattern,
+    watch: true,
+  })

--- a/src/commands/test/__tests__/index.spec.ts
+++ b/src/commands/test/__tests__/index.spec.ts
@@ -53,12 +53,14 @@ describe('success cases', () => {
     it('calls jest with args and returns success when no modes are passed', async () => {
       const result = await testCommand({})
 
-      expect(runJest).toHaveBeenCalledWith(expect.arrayContaining([
-        '--projects',
-        expect.stringContaining('project-type.js'),
-        expect.stringContaining('project-lint.js'),
-        expect.stringContaining('project-spec.js'),
-      ]))
+      expect(runJest).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          '--projects',
+          expect.stringContaining('project-type.js'),
+          expect.stringContaining('project-lint.js'),
+          expect.stringContaining('project-spec.js'),
+        ]),
+      )
 
       expect(result).toEqual({ code: 0 })
     })
@@ -66,10 +68,12 @@ describe('success cases', () => {
     it('calls jest with args and returns success when valid modes are passed', async () => {
       const result = await testCommand({ modes: ['spec'] })
 
-      expect(runJest).toHaveBeenCalledWith(expect.arrayContaining([
-        '--projects',
-        expect.stringContaining('project-spec.js'),
-      ]))
+      expect(runJest).toHaveBeenCalledWith(
+        expect.arrayContaining([
+          '--projects',
+          expect.stringContaining('project-spec.js'),
+        ]),
+      )
 
       expect(result).toEqual({ code: 0 })
     })
@@ -79,9 +83,9 @@ describe('success cases', () => {
     it('calls jest with args and returns success when no pattern is passed', async () => {
       const result = await testCommand()
 
-      expect(runJest).toHaveBeenCalledWith(expect.not.arrayContaining([
-        '--pattern',
-      ]))
+      expect(runJest).toHaveBeenCalledWith(
+        expect.not.arrayContaining(['--pattern']),
+      )
 
       expect(result).toEqual({ code: 0 })
     })
@@ -90,10 +94,9 @@ describe('success cases', () => {
       const pattern = 'utils/'
       const result = await testCommand({ pattern })
 
-      expect(runJest).toHaveBeenCalledWith(expect.arrayContaining([
-        '--testPathPattern',
-        pattern,
-      ]))
+      expect(runJest).toHaveBeenCalledWith(
+        expect.arrayContaining(['--testPathPattern', pattern]),
+      )
 
       expect(result).toEqual({ code: 0 })
     })
@@ -103,9 +106,9 @@ describe('success cases', () => {
     it('calls jest with args and returns success when no watch flag is passed', async () => {
       const result = await testCommand()
 
-      expect(runJest).toHaveBeenCalledWith(expect.not.arrayContaining([
-        '--watch',
-      ]))
+      expect(runJest).toHaveBeenCalledWith(
+        expect.not.arrayContaining(['--watch']),
+      )
 
       expect(result).toEqual({ code: 0 })
     })
@@ -113,9 +116,7 @@ describe('success cases', () => {
     it('calls jest with args and returns success when watch flag is passed', async () => {
       const result = await testCommand({ watch: true })
 
-      expect(runJest).toHaveBeenCalledWith(expect.arrayContaining([
-        '--watch',
-      ]))
+      expect(runJest).toHaveBeenCalledWith(expect.arrayContaining(['--watch']))
 
       expect(result).toEqual({ code: 0 })
     })
@@ -129,9 +130,7 @@ describe('success cases', () => {
 
       const result = await testCommand()
 
-      expect(runJest).toHaveBeenCalledWith(expect.arrayContaining([
-        '--ci',
-      ]))
+      expect(runJest).toHaveBeenCalledWith(expect.arrayContaining(['--ci']))
 
       expect(result).toEqual({ code: 0 })
 

--- a/src/commands/test/__tests__/utils.spec.ts
+++ b/src/commands/test/__tests__/utils.spec.ts
@@ -40,20 +40,28 @@ describe('getJestArgs', () => {
     it('returns single project when single valid mode is specified', () => {
       const actual = getJestArgs({ modes: ['type'], pattern: '', watch: false })
 
-      expect(actual).toEqual(expect.arrayContaining([
-        '--projects',
-        expect.stringContaining('project-type.js'),
-      ]))
+      expect(actual).toEqual(
+        expect.arrayContaining([
+          '--projects',
+          expect.stringContaining('project-type.js'),
+        ]),
+      )
     })
 
     it('returns multiple projects when multiple valid modes are specified', () => {
-      const actual = getJestArgs({ modes: ['lint', 'spec'], pattern: '', watch: false })
+      const actual = getJestArgs({
+        modes: ['lint', 'spec'],
+        pattern: '',
+        watch: false,
+      })
 
-      expect(actual).toEqual(expect.arrayContaining([
-        '--projects',
-        expect.stringContaining('project-lint.js'),
-        expect.stringContaining('project-spec.js'),
-      ]))
+      expect(actual).toEqual(
+        expect.arrayContaining([
+          '--projects',
+          expect.stringContaining('project-lint.js'),
+          expect.stringContaining('project-spec.js'),
+        ]),
+      )
     })
   })
 
@@ -62,10 +70,9 @@ describe('getJestArgs', () => {
       const pattern = 'api/'
       const actual = getJestArgs({ pattern, modes: ['lint'], watch: false })
 
-      expect(actual).toEqual(expect.arrayContaining([
-        '--testPathPattern',
-        pattern,
-      ]))
+      expect(actual).toEqual(
+        expect.arrayContaining(['--testPathPattern', pattern]),
+      )
     })
 
     it('does not include --testPathPattern flag when pattern option is empty string', () => {

--- a/src/commands/test/babel-jest-transform.js
+++ b/src/commands/test/babel-jest-transform.js
@@ -1,4 +1,4 @@
-const {resolve} = require('path')
+const { resolve } = require('path')
 const babelJest = require('babel-jest')
 
 // Special augmented babel-jest where we point to a specific

--- a/src/commands/test/eslint.config.js
+++ b/src/commands/test/eslint.config.js
@@ -7,6 +7,9 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     // 'plugin:@typescript-eslint/recommended-requiring-type-checking',
     'plugin:jest/recommended',
+    'plugin:prettier/recommended',
+    'prettier/@typescript-eslint',
+    'prettier/react',
   ],
   env: {
     jest: true,
@@ -15,12 +18,19 @@ module.exports = {
     'jest/globals': true,
   },
   parser: '@typescript-eslint/parser',
-  plugins: ['@typescript-eslint', 'jest'],
+  plugins: ['@typescript-eslint', 'jest', 'prettier'],
   // parserOptions: {
   //   project: resolve(__dirname, 'tsconfig.json'),
   // },
   settings: {
-    react: 'detect',
+    'import/resolver': {
+      node: {
+        extensions: ['.ts', '.tsx', '.js', '.jsx'],
+      },
+    },
+    react: {
+      version: 'detect',
+    },
   },
   rules: {
     // overrides of eslint-config-airbnb
@@ -62,7 +72,7 @@ module.exports = {
     'react/jsx-filename-extension': ['error', { extensions: ['.tsx', '.jsx'] }],
     'react/jsx-one-expression-per-line': 'off',
     'react/prop-types': 'off',
-    semi: ['error', 'never'],
+    // semi: ['error', 'never'],
 
     // need to be turned off for rules in plugin:@typescript-eslint/recommended
     'no-undef': 'off',
@@ -94,15 +104,17 @@ module.exports = {
     'jest/prefer-to-be-undefined': 'error',
     'jest/valid-describe': 'error',
     'jest/valid-expect-in-promise': 'error',
+
+    // eslint-config-prettier setting
+    'prettier/prettier': 'error',
   },
-  settings: {
-    'import/resolver': {
-      node: {
-        extensions: ['.ts', '.tsx', '.js', '.jsx'],
+  overrides: [
+    {
+      files: ['*.js'],
+      rules: {
+        '@typescript-eslint/no-var-requires': 'off',
+        '@typescript-eslint/explicit-function-return-type': 'off',
       },
     },
-    react: {
-      version: 'detect',
-    },
-  },
+  ],
 }

--- a/src/commands/test/eslint.config.js
+++ b/src/commands/test/eslint.config.js
@@ -1,4 +1,4 @@
-const { resolve } = require('path');
+const { resolve } = require('path')
 
 module.exports = {
   extends: [
@@ -15,10 +15,7 @@ module.exports = {
     'jest/globals': true,
   },
   parser: '@typescript-eslint/parser',
-  plugins: [
-    '@typescript-eslint',
-    'jest',
-  ],
+  plugins: ['@typescript-eslint', 'jest'],
   // parserOptions: {
   //   project: resolve(__dirname, 'tsconfig.json'),
   // },
@@ -27,32 +24,39 @@ module.exports = {
   },
   rules: {
     // overrides of eslint-config-airbnb
-    'import/extensions': ['error', 'ignorePackages', {
-      ts: 'never',
-      tsx: 'never',
-      js: 'never',
-      jsx: 'never',
-    }],
+    'import/extensions': [
+      'error',
+      'ignorePackages',
+      {
+        ts: 'never',
+        tsx: 'never',
+        js: 'never',
+        jsx: 'never',
+      },
+    ],
     'import/prefer-default-export': 'off',
-    'import/no-extraneous-dependencies': ['error', {
-      packageDir: [
-        resolve(__dirname, '../../../../'),
-        './',
-      ],
-    }],
+    'import/no-extraneous-dependencies': [
+      'error',
+      {
+        packageDir: [resolve(__dirname, '../../../../'), './'],
+      },
+    ],
     'no-restricted-syntax': [
       'error',
       {
         selector: 'ForInStatement',
-        message: 'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
+        message:
+          'for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array.',
       },
       {
         selector: 'LabeledStatement',
-        message: 'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
+        message:
+          'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
       },
       {
         selector: 'WithStatement',
-        message: '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
+        message:
+          '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
       },
     ],
     'react/jsx-filename-extension': ['error', { extensions: ['.tsx', '.jsx'] }],
@@ -60,23 +64,28 @@ module.exports = {
     'react/prop-types': 'off',
     semi: ['error', 'never'],
 
-
     // need to be turned off for rules in plugin:@typescript-eslint/recommended
     'no-undef': 'off',
     camelcase: 'off',
 
     // @typescript-eslint/eslint-plugin settings
     '@typescript-eslint/array-type': 'error',
-    '@typescript-eslint/explicit-function-return-type': ['error', {
-      allowExpressions: true,
-      allowTypedFunctionExpressions: true,
-      allowHigherOrderFunctions: true,
-    }],
+    '@typescript-eslint/explicit-function-return-type': [
+      'error',
+      {
+        allowExpressions: true,
+        allowTypedFunctionExpressions: true,
+        allowHigherOrderFunctions: true,
+      },
+    ],
     '@typescript-eslint/indent': 'off',
-    '@typescript-eslint/consistent-type-assertions': ['error', {
-      assertionStyle: 'as',
-      objectLiteralTypeAssertions: 'allow-as-parameter',
-    }],
+    '@typescript-eslint/consistent-type-assertions': [
+      'error',
+      {
+        assertionStyle: 'as',
+        objectLiteralTypeAssertions: 'allow-as-parameter',
+      },
+    ],
 
     // eslint-plugin-jest settings
     'jest/consistent-test-it': 'error',

--- a/src/commands/test/jest-runner-eslint.config.js
+++ b/src/commands/test/jest-runner-eslint.config.js
@@ -1,4 +1,4 @@
-const {resolve} = require('path')
+const { resolve } = require('path')
 
 module.exports = {
   cliOptions: {

--- a/src/commands/test/project-base.js
+++ b/src/commands/test/project-base.js
@@ -1,4 +1,5 @@
 const { resolve } = require('path')
+
 const REAL_ROOT_DIR = process.cwd()
 
 // NOTE: We really want `rootDir` to be the current working directory, but

--- a/src/commands/test/project-base.js
+++ b/src/commands/test/project-base.js
@@ -1,4 +1,4 @@
-const {resolve} = require('path')
+const { resolve } = require('path')
 const REAL_ROOT_DIR = process.cwd()
 
 // NOTE: We really want `rootDir` to be the current working directory, but

--- a/src/commands/test/project-lint.js
+++ b/src/commands/test/project-lint.js
@@ -1,8 +1,14 @@
+const { resolve } = require('path')
 const BASE_CONFIG = require('./project-base')
+
+const [ROOT_DIR] = BASE_CONFIG.roots
 
 module.exports = {
   ...BASE_CONFIG,
   runner: 'jest-runner-eslint',
   displayName: 'lint',
   watchPlugins: [...BASE_CONFIG.watchPlugins, 'jest-runner-eslint/watch-fix'],
+
+  // we can lint both typescript and javascript files
+  testMatch: [resolve(ROOT_DIR, 'src/**/*.{ts,js}?(x)')],
 }

--- a/src/commands/test/project-lint.js
+++ b/src/commands/test/project-lint.js
@@ -4,8 +4,5 @@ module.exports = {
   ...BASE_CONFIG,
   runner: 'jest-runner-eslint',
   displayName: 'lint',
-  watchPlugins: [
-    ...BASE_CONFIG.watchPlugins,
-    'jest-runner-eslint/watch-fix'
-  ],
+  watchPlugins: [...BASE_CONFIG.watchPlugins, 'jest-runner-eslint/watch-fix'],
 }

--- a/src/commands/test/project-spec.js
+++ b/src/commands/test/project-spec.js
@@ -1,4 +1,4 @@
-const {resolve} = require('path')
+const { resolve } = require('path')
 const BASE_CONFIG = require('./project-base')
 
 const [ROOT_DIR] = BASE_CONFIG.roots
@@ -13,6 +13,6 @@ module.exports = {
 
   setupFilesAfterEnv: [
     '@testing-library/jest-dom/extend-expect',
-    resolve(__dirname, 'spec-setup.js')
+    resolve(__dirname, 'spec-setup.js'),
   ],
 }

--- a/src/commands/test/spec-setup.js
+++ b/src/commands/test/spec-setup.js
@@ -10,6 +10,8 @@ const CONSOLE_FAIL_TYPES = ['error', 'warn']
 CONSOLE_FAIL_TYPES.forEach((type) => {
   // eslint-disable-next-line no-console
   console[type] = (message) => {
-    throw new Error(`Failing due to console.${type} while running test!\n\n${message}`)
+    throw new Error(
+      `Failing due to console.${type} while running test!\n\n${message}`,
+    )
   }
 })

--- a/src/commands/test/utils.ts
+++ b/src/commands/test/utils.ts
@@ -2,15 +2,15 @@ import { resolve } from 'path'
 import { TestMode } from '../types'
 
 interface ValidTestModes {
-  type: string;
-  lint: string;
-  spec: string;
-  [index: string]: string;
+  type: string
+  lint: string
+  spec: string
+  [index: string]: string
 }
 export interface Args {
-  modes: TestMode[];
-  pattern: string;
-  watch: boolean;
+  modes: TestMode[]
+  pattern: string
+  watch: boolean
 }
 
 // NOTE: Ideally we'd point to project configuration objects for
@@ -53,7 +53,6 @@ export const getJestArgs = ({ modes, pattern, watch }: Args): string[] => {
   if (process.env.CI === 'true') {
     jestArgs.push('--ci')
   }
-
 
   return jestArgs
 }

--- a/src/commands/types.ts
+++ b/src/commands/types.ts
@@ -3,7 +3,7 @@ export type ModuleFormat = 'type' | 'esm' | 'cjs'
 export type TestMode = 'type' | 'lint' | 'spec'
 
 export interface Result {
-  readonly code?: number;
-  readonly error?: Error;
-  readonly message?: string;
+  readonly code?: number
+  readonly error?: Error
+  readonly message?: string
 }


### PR DESCRIPTION
## Problem

Want to add [`prettier`](https://prettier.io/) support mainly to make development easier so that code auto-formats on save. But if we have `prettier,` we might as well integrate it into CI somehow.


## Solution

The solution is multi-pronged:

- Added `.prettierrc.json` and `.vscode/settings.json` in order to have code formatting on save. This applies to all file times `.ts`, `.js`, `.json`, `.md`, etc
- Added a new job in `.github/workflows/ci.yml` that runs the `prettier` CLI and overwrites the files with the changes. If there are file changes, it pushes a new auto-commit to the branch with new changes. That way any changes that were missed will get caught by CI. As a result of the push, CI will run _again_ and we can make sure that running `prettier` didn't break any test with malformed files. Since this was the first run of `prettier`, **lots** of files were updated
- Added `prettier` check as part of linting with [`@typescript-eslint/eslint-plugin`](https://github.com/typescript-eslint/typescript-eslint/tree/master/packages/eslint-plugin). This will fail `benmvp test` if there are malformed files, but most should be fixable when running `benmvp start`
- `benmvp integrate` runs `benmvp test` within the `integration-tests/` project, but it needs the same `.prettierrc.json` so those are copied over as part of the script that runs the integration test

In the end, it'll be the responsibility of `benmvp start` to create a new project with prettier configs. They will be something that each library can change themselves, allowing a bit of configuration, but the idea is that they wouldn't be. I had to make the file part of the host library instead of within `benmvp-cli` in order to make the dev environment work properly.

BREAKING CHANGE: Although CI will auto-format, `benmvp test` will fail because prettier now runs on all the files