### PR TITLE
feat!: Add linting for react-testing-library

### DIFF
--- a/src/commands/test/eslint.config.js
+++ b/src/commands/test/eslint.config.js
@@ -7,6 +7,7 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     // 'plugin:@typescript-eslint/recommended-requiring-type-checking',
     'plugin:jest/recommended',
+    'plugin:testing-library/react',
     'plugin:prettier/recommended',
     'prettier/@typescript-eslint',
     'prettier/react',
@@ -72,7 +73,6 @@ module.exports = {
     'react/jsx-filename-extension': ['error', { extensions: ['.tsx', '.jsx'] }],
     'react/jsx-one-expression-per-line': 'off',
     'react/prop-types': 'off',
-    // semi: ['error', 'never'],
 
     // need to be turned off for rules in plugin:@typescript-eslint/recommended
     'no-undef': 'off',


### PR DESCRIPTION
## Problem

There was no linting for [`@testing-library/react`](https://testing-library.com/docs/react-testing-library/intro) yet the `package.json` was already installing [`eslint-plugin-testing-library`](https://github.com/Belco90/eslint-plugin-testing-library).


## Solution

Added `'plugin:testing-library/react'` as one of the plugins the `eslint.config.js` extends from to receive the recommended react ESLint rules.

Fixes #81 

BREAKING CHANGE: This is now failing for new lint errors so it's technically a breaking change, although it should be super-duper minor.