### PR TITLE
fix(create): Add messaging when done

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,16 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Double check unit tests
+        run: npm test
+        env:
+          CI: true
+
+      - name: Double check integration tests
+        run: npm run integrate
+        env:
+          CI: true
+
       - name: Build package
         run: npm run build
 

--- a/src/commands/create/index.ts
+++ b/src/commands/create/index.ts
@@ -88,6 +88,13 @@ export default async ({
       modes,
     })
     await replaceRepoNameReferences(sanitizedLibraryName)
+
+    // eslint-disable-next-line no-console
+    console.log(
+      libraryName
+        ? `${libraryName} successfully created.`
+        : 'Repo successfully updated',
+    )
   } catch (error) {
     return {
       code: error.code || 1,

--- a/src/commands/create/index.ts
+++ b/src/commands/create/index.ts
@@ -92,8 +92,8 @@ export default async ({
     // eslint-disable-next-line no-console
     console.log(
       libraryName
-        ? `${libraryName} successfully created.`
-        : 'Repo successfully updated',
+        ? `DONE! ${libraryName} successfully created.`
+        : 'DONE! Repo successfully updated.',
     )
   } catch (error) {
     return {

--- a/src/commands/create/init.sh
+++ b/src/commands/create/init.sh
@@ -40,12 +40,12 @@ git status || echo -e "git init\n" && git init
 # Create index file if it doesn't already exist
 mkdir -p src/
 if [ ! -f "src/index.ts" ]; then
-  echo -e "Creating src/index.ts file\n"
+  echo -e "Creating dummy src/index.ts file.\n"
   echo -e "// Root index file for the library\n// Export top-level functions here" > src/index.ts
 fi
 
 # Copy miscellaneous config and repo files
+echo -e "Copying repo config files.\n"
 DIRNAME=`dirname $0`
 CONFIGS_PATH="$DIRNAME/../../../configs"
-echo -e "cp -r $CONFIGS_PATH/. ./"
 cp -r $CONFIGS_PATH/. ./


### PR DESCRIPTION
## Problem

After running the `create` command there's no messaging indicating that the library was successfully created. In fact, the last thing rendered to the screen is the `cp` command that copies over the config files. I actually thought the command was broken and the `cp` had failed.


## Solution

Replaced the `cp` command with friendly text that says "Copying repo config files." and more importantly when the creation is completed it says "[repoName] successfully created" if the library name was specified (new lib) or "Repo successfully updated" for an existing repo.

Also added an update to the `release` workflow to run the unit tests one more time as a double check to make sure we're not releasing broken code that's merged into `master`.
